### PR TITLE
Fix inline math wrongly triggered by currency dollar signs (#75)

### DIFF
--- a/Dev/Typedown.Editor/src/components/Muya/lib/parser/marked/inlineRules.js
+++ b/Dev/Typedown.Editor/src/components/Muya/lib/parser/marked/inlineRules.js
@@ -37,7 +37,7 @@ const inline = {
   emoji: noop,
 
   // TODO: make math optional GH#740
-  math: /^\$([^$]*?[^\$\\])\$(?!\$)/,
+  math: /^\$(?!\s)([^$]*?[^\s$\\])\$(?![\d$])/,
 
   // superscript and subScript
   superscript: /^(\^)((?:[^\^\s]|(?<=\\)\1|(?<=\\) )+?)(?<!\\)\1(?!\1)/,

--- a/Dev/Typedown.Editor/src/components/Muya/lib/parser/rules.js
+++ b/Dev/Typedown.Editor/src/components/Muya/lib/parser/rules.js
@@ -34,7 +34,7 @@ export const inlineRules = {
   backlash: /^(\\)([\\`*{}\[\]()#+\-.!_>~:\|\<\>$]{1})/,
 
   // Markdown extensions (not belongs to GFM and Commonmark)
-  inline_math: /^(\$)([^\$]*?[^\$\\])(\\*)\1(?!\1)/
+  inline_math: /^(\$)(?!\s)([^\$]*?[^\s\$\\])(\\*)\1(?![\d$])/
 }
 
 // Markdown extensions (not belongs to GFM and Commonmark)


### PR DESCRIPTION
## Summary
Fixes #75. Currency amounts written with `$` (e.g. `$29,211 and $34,390`) were being parsed as paired inline-math (`$...$`) delimiters, so the dollar signs vanished and the text between them rendered as italic math.

## Fix
Updates the inline-math delimiter rule in both the live-editor parser (`rules.js`) and the markdown importer (`inlineRules.js`) to use the standard Pandoc/KaTeX heuristic:

- the opening `$` must **not** be followed by whitespace, and
- the closing `$` must **not** be preceded by whitespace and must **not** be immediately followed by a digit.

Every `$` in a currency amount is immediately followed by a digit, so currency no longer forms a math span — while genuine math like `$x+y$`, `$E=mc^2$`, `$\frac{1}{2}$`, and even number-leading math such as `$4 + xy$` still renders correctly.

## Testing
Built and verified in the app: currency renders as plain text and inline/block math still render. Also validated the regex against currency chains and a range of math expressions.

Closes #75