### PR TITLE
feat: add multi-tab document editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ _TeamCity*
 _NCrunch_*
 .*crunch*.local.xml
 nCrunchTemp_*
+/.worktrees/
 
 # MightyMoose
 *.mm.*

--- a/.superpowers/sdd/task-3-report.md
+++ b/.superpowers/sdd/task-3-report.md
@@ -88,3 +88,57 @@ Observed environment blockers:
 - stayed on the existing IPC surfaces (`transport` + `RemoteInvoke`), with no second channel or new dependency;
 - preserved existing editor behaviors for search, export/import, settings listeners, Muya, and CodeMirror;
 - kept C# build status honest: attempted, blocked by environment, not reported as passing.
+
+## Review Fix Follow-up
+
+### Issues addressed
+
+1. `Editor/index.tsx` no longer feeds externally synchronized markdown/cursor back into parent tab state as if they were user edits.
+2. `TabCoordinator.tsx` no longer posts `LoadFile` from React during tab switches; the active document now changes through the existing controlled `Editor` props path, while `ActivateTab` remains the host-side state sync.
+3. Added a focused `Editor` test that renders the real `Editor` component with thin Muya/CodeMirror mocks and verifies external prop changes do not call parent edit callbacks. The failed-save coordinator test now explicitly asserts the tab remains dirty.
+
+### RED
+
+After adding the new focused tests and tightening the coordinator expectation, this command failed as expected:
+
+```powershell
+node node_modules/react-app-rewired/bin/index.js test --watchAll=false --testMatch "**/tabModel.test.ts" --testMatch "**/TabCoordinator.test.tsx" --testMatch "**/Editor/index.test.tsx"
+```
+
+Meaningful failures observed:
+
+- `external markdown and cursor sync does not call parent edit callbacks` failed because `onMarkdownChange` was called during external prop sync.
+- `switching calls activateTab before loading the target document into the editor` failed because the coordinator still emitted `post:LoadFile`.
+
+### GREEN
+
+Minimal fixes applied:
+
+- added callback-suppression refs in `Dev/Typedown.Editor/src/components/Editor/index.tsx` so external prop sync does not trigger parent edit callbacks;
+- kept user-edit callbacks intact after the external sync completes;
+- removed the invalid coordinator-side `LoadFile` post and kept the tab switch path as `TabCoordinator -> Editor props` plus `remote.activateTab`.
+
+### Verification evidence
+
+Focused tests passed:
+
+```powershell
+node node_modules/react-app-rewired/bin/index.js test --watchAll=false --testMatch "**/tabModel.test.ts" --testMatch "**/TabCoordinator.test.tsx" --testMatch "**/Editor/index.test.tsx"
+```
+
+Result: `3` suites passed, `24` tests passed.
+
+Frontend build passed:
+
+```powershell
+node node_modules/react-app-rewired/bin/index.js build
+```
+
+Result: production build completed successfully with only pre-existing vendor/library warnings.
+
+### Files updated in review fix
+
+- `Dev/Typedown.Editor/src/components/Editor/index.tsx`
+- `Dev/Typedown.Editor/src/components/Editor/index.test.tsx`
+- `Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.tsx`
+- `Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.test.tsx`

--- a/.superpowers/sdd/task-3-report.md
+++ b/.superpowers/sdd/task-3-report.md
@@ -1,0 +1,90 @@
+# Task 3 Report
+
+## Scope
+
+Implemented Task 3 in `E:\self\playground\typedown-original\.worktrees\multi-tab` on branch `feature/multi-tab`:
+
+- added a single `TabCoordinator` that owns tab state and keeps one editor instance;
+- wired editor markdown/cursor callbacks back into React tab state;
+- switched `FileViewModel` New/Open/Save/SaveAs command producers to tab events;
+- kept the existing remote invoke path (`ActivateTab`, `SaveTab`, `CloseWindow`) and the existing `LoadFile` editor message.
+
+## RED
+
+1. Added `Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.test.tsx`.
+2. Verified an initial RED when `TabCoordinator` did not exist yet.
+3. Tightened the test harness so the suite failed for real coordinator behavior instead of Jest mock factory issues.
+
+## GREEN
+
+Implemented:
+
+- `Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.tsx`
+- `Dev/Typedown.Editor/src/components/Editor/index.tsx`
+- `Dev/Typedown.Editor/src/App.tsx`
+- `Dev/Typedown.Core/ViewModels/FileViewModel.cs`
+
+Key outcomes:
+
+- startup settings create exactly one tab and one editor instance;
+- `DocumentLoaded` opens a canonical-path tab or activates an existing one;
+- editor changes update only the active tab snapshot;
+- tab switching calls `activateTab` before posting `LoadFile`;
+- failed `saveTab` keeps the active tab dirty;
+- `NewTabRequested` creates a new untitled tab without replacing existing tabs;
+- clean last-tab close calls `CloseWindow`;
+- `OpenFileCommand` emits `DocumentLoaded` with `{ path, text, basePath, dirty }`;
+- backup-recovered open state stays dirty via the emitted `dirty` flag.
+
+## Verification
+
+### Focused frontend tests
+
+Passed:
+
+```powershell
+node node_modules/react-app-rewired/bin/index.js test --watchAll=false --testMatch "**/tabModel.test.ts" --testMatch "**/TabCoordinator.test.tsx"
+```
+
+Result: `2` suites passed, `22` tests passed.
+
+### Frontend build
+
+Passed:
+
+```powershell
+node node_modules/react-app-rewired/bin/index.js build
+```
+
+Result: production build completed successfully.
+
+Note: build still reports pre-existing lint warnings in Muya/vendor files and `sequence-diagram-snap.js`; no new task-specific build warning remains.
+
+### C# build
+
+Not passing in this environment; blocker recorded, not claimed green:
+
+```powershell
+dotnet build Typedown.sln
+```
+
+Observed environment blockers:
+
+- access denied reading `C:\Users\temp\AppData\Roaming\NuGet\NuGet.Config`
+- `Microsoft.VisualStudio.JavaScript.Sdk` could not be resolved from this environment
+
+## Files changed
+
+- `Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.tsx`
+- `Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.test.tsx`
+- `Dev/Typedown.Editor/src/components/Editor/index.tsx`
+- `Dev/Typedown.Editor/src/App.tsx`
+- `Dev/Typedown.Core/ViewModels/FileViewModel.cs`
+- `.superpowers/sdd/task-3-report.md`
+
+## Self-review
+
+- kept a single editor instance; no per-tab Muya/CodeMirror mount was introduced;
+- stayed on the existing IPC surfaces (`transport` + `RemoteInvoke`), with no second channel or new dependency;
+- preserved existing editor behaviors for search, export/import, settings listeners, Muya, and CodeMirror;
+- kept C# build status honest: attempted, blocked by environment, not reported as passing.

--- a/Dev/Typedown.Core/ViewModels/EditorViewModel.cs
+++ b/Dev/Typedown.Core/ViewModels/EditorViewModel.cs
@@ -114,6 +114,7 @@ namespace Typedown.Core.ViewModels
                 Settings.EditorAreaWidth,
                 Settings.TabSize,
                 Markdown,
+                FilePath = FileViewModel.FilePath,
                 BasePath = FileViewModel.ImageBasePath,
             };
         }

--- a/Dev/Typedown.Core/ViewModels/FileViewModel.cs
+++ b/Dev/Typedown.Core/ViewModels/FileViewModel.cs
@@ -65,14 +65,34 @@ namespace Typedown.Core.ViewModels
 
         private readonly CompositeDisposable disposables = new();
 
+        private sealed class ActivateTabArgs
+        {
+            public string Path { get; set; }
+            public string Text { get; set; }
+            public bool Dirty { get; set; }
+        }
+
+        private sealed class SaveTabArgs
+        {
+            public string Path { get; set; }
+            public string Text { get; set; }
+            public bool SaveAs { get; set; }
+        }
+
+        private sealed class SaveTabResult
+        {
+            public string Path { get; set; }
+            public string BasePath { get; set; }
+        }
+
         public FileViewModel(IServiceProvider serviceProvider)
         {
             ServiceProvider = serviceProvider;
-            NewFileCommand.OnExecute.Subscribe(async _ => await NewFileFun());
+            NewFileCommand.OnExecute.Subscribe(_ => RequestNewTab());
             OpenFileCommand.OnExecute.Subscribe(async x => await OpenFile(x));
             OpenFolderCommand.OnExecute.Subscribe(async x => await OpenFolder(x));
-            SaveAsCommand.OnExecute.Subscribe(async _ => await SaveAs());
-            SaveCommand.OnExecute.Subscribe(async _ => await Save());
+            SaveAsCommand.OnExecute.Subscribe(_ => RequestSave(true));
+            SaveCommand.OnExecute.Subscribe(_ => RequestSave(false));
             ExitCommand.OnExecute.Subscribe(_ => Exit());
             ClearHistoryCommand.OnExecute.Subscribe(x => { _ = AccessHistory.ClearHistory(); });
             ExportCommand.OnExecute.Subscribe(Export);
@@ -80,6 +100,9 @@ namespace Typedown.Core.ViewModels
             ImportCommand.OnExecute.Subscribe(_ => Import());
             RemoteInvoke.Handle<JToken, bool>("ExportCallback", ExportCallback);
             RemoteInvoke.Handle<JToken, bool>("PrintHTML", PrintHTML);
+            RemoteInvoke.Handle<ActivateTabArgs>("ActivateTab", ActivateTab);
+            RemoteInvoke.Handle<SaveTabArgs, SaveTabResult>("SaveTab", SaveTab);
+            RemoteInvoke.Handle("CloseWindow", CloseWindow);
             saveFileTimer.Interval = TimeSpan.FromSeconds(5);
             saveFileTimer.Tick += SaveFileTimerTick;
             saveFileTimer.Start();
@@ -162,8 +185,6 @@ namespace Typedown.Core.ViewModels
 
         public async Task<bool> OpenFile(string filePath = null)
         {
-            if (!await AskToSave())
-                return false;
             filePath ??= await AppViewModel.MainWindow.PickMarkdownFileAsync();
             if (filePath == null)
                 return false;
@@ -224,7 +245,12 @@ namespace Typedown.Core.ViewModels
                 EditorViewModel.History.InitHistory(EditorViewModel.Markdown);
                 if (postMessage)
                 {
-                    MarkdownEditor?.PostMessage("LoadFile", new { text = EditorViewModel.Markdown, basePath = ImageBasePath });
+                    MarkdownEditor?.PostMessage("DocumentLoaded", new
+                    {
+                        path = FilePath,
+                        text = EditorViewModel.Markdown,
+                        basePath = ImageBasePath
+                    });
                 }
                 return true;
             }
@@ -294,28 +320,7 @@ namespace Typedown.Core.ViewModels
             }
         }
 
-        private async Task<bool> Save(bool alert = true)
-        {
-            if (FilePath == null)
-            {
-                var result = await SaveAs();
-                return result != null;
-            }
-            else
-            {
-                var result = await WriteAllText(FilePath, EditorViewModel.Markdown, alert);
-                if (result)
-                {
-                    EditorViewModel.FileHash = EditorViewModel.CurrentHash;
-                    EditorViewModel.Saved = true;
-                    AutoBackup.DeleteBackup(FilePath);
-                    _ = AccessHistory.RecordFileHistory(FilePath);
-                }
-                return result;
-            }
-        }
-
-        private async Task<string> SaveAs()
+        private async Task<string> PickSaveFilePath()
         {
             try
             {
@@ -324,26 +329,53 @@ namespace Typedown.Core.ViewModels
                 filePicker.FileTypeChoices.Add("Markdown Files", FileTypeHelper.Markdown.ToList());
                 filePicker.SuggestedFileName = FileName ?? "untitled";
                 var file = await filePicker.PickSaveFileAsync();
-                if (file != null)
-                {
-                    var result = await WriteAllText(file.Path, EditorViewModel.Markdown);
-                    if (result)
-                    {
-                        AutoBackup.DeleteBackup(FilePath);
-                        FilePath = file.Path;
-                        EditorViewModel.FileHash = EditorViewModel.CurrentHash;
-                        EditorViewModel.Saved = true;
-                        _ = AccessHistory.RecordFileHistory(FilePath);
-                        return file.Path;
-                    }
-                }
-                return null;
+                return file?.Path;
             }
             catch (Exception ex)
             {
                 await AppContentDialog.Create(Locale.GetString("Error"), ex.Message, Locale.GetString("Ok")).ShowAsync(AppViewModel.XamlRoot);
                 return null;
             }
+        }
+
+        private async Task<string> SaveText(string path, string text, bool saveAs, bool alert = true)
+        {
+            var targetPath = saveAs || path == null ? await PickSaveFilePath() : path;
+            if (targetPath == null)
+                return null;
+            return await WriteAllText(targetPath, text, alert) ? targetPath : null;
+        }
+
+        private void ApplySavedState(string path, string text)
+        {
+            var previousPath = FilePath;
+            AutoBackup.DeleteBackup(previousPath);
+            FilePath = path;
+            EditorViewModel.Markdown = text;
+            EditorViewModel.CurrentHash = Common.SimpleHash(text);
+            EditorViewModel.FileHash = EditorViewModel.CurrentHash;
+            EditorViewModel.Saved = true;
+            EditorViewModel.AutoSavedSucc = true;
+            AutoBackup.DeleteBackup(FilePath);
+            _ = AccessHistory.RecordFileHistory(FilePath);
+        }
+
+        private async Task<bool> Save(bool alert = true)
+        {
+            var result = await SaveText(FilePath, EditorViewModel.Markdown, FilePath == null, alert);
+            if (result == null)
+                return false;
+            ApplySavedState(result, EditorViewModel.Markdown);
+            return true;
+        }
+
+        private async Task<string> SaveAs()
+        {
+            var result = await SaveText(FilePath, EditorViewModel.Markdown, true);
+            if (result == null)
+                return null;
+            ApplySavedState(result, EditorViewModel.Markdown);
+            return result;
         }
 
         private async Task<bool> PrintHTML(JToken args)
@@ -437,7 +469,7 @@ namespace Typedown.Core.ViewModels
                     case Enums.FileStartupAction.OpenLast:
                         await AccessHistory.EnsureInitialized();
                         if (AccessHistory.FileRecentlyOpened.FirstOrDefault() is string lastFile && !TryGetOpenedWindow(lastFile, out _) && File.Exists(lastFile))
-                            await LoadFile(lastFile, true);
+                            await LoadFile(lastFile, true, false);
                         break;
                     default:
                         await NewFileFun(false);
@@ -549,6 +581,43 @@ namespace Typedown.Core.ViewModels
         {
             saveFileTimer.Stop();
             disposables.Dispose();
+        }
+
+        private void RequestNewTab()
+        {
+            MarkdownEditor?.PostMessage("NewTabRequested", null);
+        }
+
+        private void RequestSave(bool saveAs)
+        {
+            MarkdownEditor?.PostMessage("SaveRequested", new { saveAs });
+        }
+
+        private void ActivateTab(ActivateTabArgs args)
+        {
+            var text = args?.Text ?? string.Empty;
+            var currentHash = Common.SimpleHash(text);
+
+            FilePath = args?.Path;
+            EditorViewModel.Markdown = text;
+            EditorViewModel.CurrentHash = currentHash;
+            EditorViewModel.FileHash = args?.Dirty == true ? currentHash ^ 1UL : currentHash;
+            EditorViewModel.Saved = args?.Dirty != true;
+        }
+
+        private async Task<SaveTabResult> SaveTab(SaveTabArgs args)
+        {
+            var text = args?.Text ?? string.Empty;
+            var result = await SaveText(args?.Path, text, args?.SaveAs == true || args?.Path == null);
+            if (result == null)
+                return null;
+            ApplySavedState(result, text);
+            return new SaveTabResult() { Path = result, BasePath = ImageBasePath };
+        }
+
+        private void CloseWindow()
+        {
+            Exit();
         }
 
         private void Exit()

--- a/Dev/Typedown.Core/ViewModels/FileViewModel.cs
+++ b/Dev/Typedown.Core/ViewModels/FileViewModel.cs
@@ -88,11 +88,11 @@ namespace Typedown.Core.ViewModels
         public FileViewModel(IServiceProvider serviceProvider)
         {
             ServiceProvider = serviceProvider;
-            NewFileCommand.OnExecute.Subscribe(_ => RequestNewTab());
+            NewFileCommand.OnExecute.Subscribe(async _ => await NewFileFun());
             OpenFileCommand.OnExecute.Subscribe(async x => await OpenFile(x));
             OpenFolderCommand.OnExecute.Subscribe(async x => await OpenFolder(x));
-            SaveAsCommand.OnExecute.Subscribe(_ => RequestSave(true));
-            SaveCommand.OnExecute.Subscribe(_ => RequestSave(false));
+            SaveAsCommand.OnExecute.Subscribe(async _ => await SaveAs());
+            SaveCommand.OnExecute.Subscribe(async _ => await Save());
             ExitCommand.OnExecute.Subscribe(_ => Exit());
             ClearHistoryCommand.OnExecute.Subscribe(x => { _ = AccessHistory.ClearHistory(); });
             ExportCommand.OnExecute.Subscribe(Export);
@@ -185,6 +185,8 @@ namespace Typedown.Core.ViewModels
 
         public async Task<bool> OpenFile(string filePath = null)
         {
+            if (!await AskToSave())
+                return false;
             filePath ??= await AppViewModel.MainWindow.PickMarkdownFileAsync();
             if (filePath == null)
                 return false;
@@ -245,12 +247,7 @@ namespace Typedown.Core.ViewModels
                 EditorViewModel.History.InitHistory(EditorViewModel.Markdown);
                 if (postMessage)
                 {
-                    MarkdownEditor?.PostMessage("DocumentLoaded", new
-                    {
-                        path = FilePath,
-                        text = EditorViewModel.Markdown,
-                        basePath = ImageBasePath
-                    });
+                    MarkdownEditor?.PostMessage("LoadFile", new { text = EditorViewModel.Markdown, basePath = ImageBasePath });
                 }
                 return true;
             }
@@ -581,16 +578,6 @@ namespace Typedown.Core.ViewModels
         {
             saveFileTimer.Stop();
             disposables.Dispose();
-        }
-
-        private void RequestNewTab()
-        {
-            MarkdownEditor?.PostMessage("NewTabRequested", null);
-        }
-
-        private void RequestSave(bool saveAs)
-        {
-            MarkdownEditor?.PostMessage("SaveRequested", new { saveAs });
         }
 
         private void ActivateTab(ActivateTabArgs args)

--- a/Dev/Typedown.Core/ViewModels/FileViewModel.cs
+++ b/Dev/Typedown.Core/ViewModels/FileViewModel.cs
@@ -88,11 +88,11 @@ namespace Typedown.Core.ViewModels
         public FileViewModel(IServiceProvider serviceProvider)
         {
             ServiceProvider = serviceProvider;
-            NewFileCommand.OnExecute.Subscribe(async _ => await NewFileFun());
-            OpenFileCommand.OnExecute.Subscribe(async x => await OpenFile(x));
+            NewFileCommand.OnExecute.Subscribe(async _ => await RequestNewTab());
+            OpenFileCommand.OnExecute.Subscribe(async x => await OpenFileInTabs(x));
             OpenFolderCommand.OnExecute.Subscribe(async x => await OpenFolder(x));
-            SaveAsCommand.OnExecute.Subscribe(async _ => await SaveAs());
-            SaveCommand.OnExecute.Subscribe(async _ => await Save());
+            SaveAsCommand.OnExecute.Subscribe(_ => RequestSave(true));
+            SaveCommand.OnExecute.Subscribe(_ => RequestSave(false));
             ExitCommand.OnExecute.Subscribe(_ => Exit());
             ClearHistoryCommand.OnExecute.Subscribe(x => { _ = AccessHistory.ClearHistory(); });
             ExportCommand.OnExecute.Subscribe(Export);
@@ -150,9 +150,9 @@ namespace Typedown.Core.ViewModels
             return true;
         }
 
-        private async Task NewFileFun(bool postMessage = true)
+        private async Task NewFileFun(bool postMessage = true, bool askToSave = true)
         {
-            if (!await AskToSave()) return;
+            if (askToSave && !await AskToSave()) return;
             FilePath = null;
             EditorViewModel.FileHash = Common.SimpleHash(Common.DefaultMarkdwn);
             string backup = null;
@@ -183,6 +183,17 @@ namespace Typedown.Core.ViewModels
             }
         }
 
+        private async Task RequestNewTab()
+        {
+            await NewFileFun(false, false);
+            MarkdownEditor?.PostMessage("NewTabRequested", new
+            {
+                text = EditorViewModel.Markdown,
+                basePath = ImageBasePath,
+                dirty = !EditorViewModel.Saved
+            });
+        }
+
         public async Task<bool> OpenFile(string filePath = null)
         {
             if (!await AskToSave())
@@ -191,6 +202,24 @@ namespace Typedown.Core.ViewModels
             if (filePath == null)
                 return false;
             return await LoadFile(filePath, true);
+        }
+
+        private async Task<bool> OpenFileInTabs(string filePath = null)
+        {
+            filePath ??= await AppViewModel.MainWindow.PickMarkdownFileAsync();
+            if (filePath == null)
+                return false;
+            var loaded = await LoadFile(filePath, true, false);
+            if (!loaded)
+                return false;
+            MarkdownEditor?.PostMessage("DocumentLoaded", new
+            {
+                path = FilePath,
+                text = EditorViewModel.Markdown,
+                basePath = ImageBasePath,
+                dirty = !EditorViewModel.Saved
+            });
+            return true;
         }
 
         public async Task<bool> OpenFolder(string folderPath = null)
@@ -373,6 +402,11 @@ namespace Typedown.Core.ViewModels
                 return null;
             ApplySavedState(result, EditorViewModel.Markdown);
             return result;
+        }
+
+        private void RequestSave(bool saveAs)
+        {
+            MarkdownEditor?.PostMessage("SaveRequested", new { saveAs });
         }
 
         private async Task<bool> PrintHTML(JToken args)
@@ -590,6 +624,11 @@ namespace Typedown.Core.ViewModels
             EditorViewModel.CurrentHash = currentHash;
             EditorViewModel.FileHash = args?.Dirty == true ? currentHash ^ 1UL : currentHash;
             EditorViewModel.Saved = args?.Dirty != true;
+            EditorViewModel.AutoSavedSucc = true;
+            EditorViewModel.FileLoaded = true;
+            EditorViewModel.History.InitHistory(text);
+            if (!string.IsNullOrEmpty(FilePath))
+                _ = AccessHistory.RecordFileHistory(FilePath);
         }
 
         private async Task<SaveTabResult> SaveTab(SaveTabArgs args)

--- a/Dev/Typedown.Editor/src/App.scss
+++ b/Dev/Typedown.Editor/src/App.scss
@@ -1,3 +1,10 @@
+.app-layout {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+}
+
 body {
     margin: 0;
     min-width: 400px;

--- a/Dev/Typedown.Editor/src/App.tsx
+++ b/Dev/Typedown.Editor/src/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import Editor from 'components/Editor';
 import ErrorBoundary from 'components/ErrorBoundary';
+import TabCoordinator from 'components/Tabs/TabCoordinator';
 import 'services/theme'
 import 'services/scrollbar'
 import 'services/localization'
@@ -11,7 +11,7 @@ document.oncontextmenu = () => false;
 function App() {
   return (
     <ErrorBoundary>
-      <Editor />
+      <TabCoordinator />
     </ErrorBoundary>
   );
 }

--- a/Dev/Typedown.Editor/src/components/Editor/index.test.tsx
+++ b/Dev/Typedown.Editor/src/components/Editor/index.test.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+type Listener = (args: any) => void;
+
+const mockListeners = new Map<string, Listener>();
+const mockPostMessage = jest.fn();
+const mockPrintHtml = jest.fn();
+const mockExportCallback = jest.fn();
+
+jest.mock('services/exportHtml', () => {
+  return {
+    __esModule: true,
+    default: class MockExportHtml {
+      generate() {
+        return Promise.resolve('<html />');
+      }
+    },
+  };
+});
+
+jest.mock('services/importHtml', () => ({
+  __esModule: true,
+  htmlToMarkdown: jest.fn(() => 'imported markdown'),
+}));
+
+jest.mock('services/common', () => ({
+  __esModule: true,
+  getHtmlToc: jest.fn(() => ''),
+  getTOC: jest.fn(() => ({ toc: [] })),
+}));
+
+jest.mock('services/remote', () => ({
+  remote: {
+    printHTML: (...args: unknown[]) => mockPrintHtml(...args),
+    exportCallback: (...args: unknown[]) => mockExportCallback(...args),
+  },
+}));
+
+jest.mock('services/transport', () => ({
+  __esModule: true,
+  default: {
+    addListener: (eventName: string, listener: Listener) => {
+      mockListeners.set(eventName, listener);
+      return () => {
+        mockListeners.delete(eventName);
+      };
+    },
+    postMessage: (...args: unknown[]) => mockPostMessage(...args),
+  },
+}));
+
+jest.mock('components/Muya', () => {
+  const MockMuya = ({
+    markdown,
+    onMarkdownChange,
+    onCursorChange,
+  }: {
+    markdown: string;
+    onMarkdownChange: (markdown: string) => void;
+    onCursorChange: (cursor: unknown) => void;
+  }) => (
+    <div>
+      <div data-testid="muya-markdown">{markdown}</div>
+      <button onClick={() => onMarkdownChange('user markdown')} type="button">emit markdown</button>
+      <button onClick={() => onCursorChange({ line: 7, ch: 3 })} type="button">emit cursor</button>
+    </div>
+  );
+
+  return {
+    __esModule: true,
+    default: MockMuya,
+  };
+});
+
+jest.mock('components/CodeMirror', () => {
+  const MockCodeMirror = ({ markdown }: { markdown: string }) => (
+    <div data-testid="codemirror-markdown">{markdown}</div>
+  );
+
+  return {
+    __esModule: true,
+    default: MockCodeMirror,
+  };
+});
+
+import Editor from './index';
+
+beforeEach(() => {
+  mockListeners.clear();
+  mockPostMessage.mockReset();
+  mockPrintHtml.mockReset();
+  mockExportCallback.mockReset();
+});
+
+test('external markdown and cursor sync does not call parent edit callbacks', () => {
+  const onMarkdownChange = jest.fn();
+  const onCursorChange = jest.fn();
+  const options = { sourceCode: false, focusMode: false, typewriter: false };
+  const view = render(
+    <Editor
+      basePath="c:\\docs"
+      cursor={{ line: 1, ch: 1 }}
+      markdown="first markdown"
+      onCursorChange={onCursorChange}
+      onMarkdownChange={onMarkdownChange}
+      options={options}
+    />,
+  );
+
+  onMarkdownChange.mockClear();
+  onCursorChange.mockClear();
+
+  view.rerender(
+    <Editor
+      basePath="c:\\next"
+      cursor={{ line: 9, ch: 4 }}
+      markdown="second markdown"
+      onCursorChange={onCursorChange}
+      onMarkdownChange={onMarkdownChange}
+      options={options}
+    />,
+  );
+
+  expect(screen.getByTestId('muya-markdown')).toHaveTextContent('second markdown');
+  expect(onMarkdownChange).not.toHaveBeenCalled();
+  expect(onCursorChange).not.toHaveBeenCalled();
+});
+
+test('user edits still call parent callbacks after external sync', () => {
+  const onMarkdownChange = jest.fn();
+  const onCursorChange = jest.fn();
+  const options = { sourceCode: false, focusMode: false, typewriter: false };
+  const view = render(
+    <Editor
+      basePath="c:\\docs"
+      cursor={{ line: 1, ch: 1 }}
+      markdown="first markdown"
+      onCursorChange={onCursorChange}
+      onMarkdownChange={onMarkdownChange}
+      options={options}
+    />,
+  );
+
+  onMarkdownChange.mockClear();
+  onCursorChange.mockClear();
+
+  view.rerender(
+    <Editor
+      basePath="c:\\next"
+      cursor={{ line: 9, ch: 4 }}
+      markdown="second markdown"
+      onCursorChange={onCursorChange}
+      onMarkdownChange={onMarkdownChange}
+      options={options}
+    />,
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: 'emit markdown' }));
+  fireEvent.click(screen.getByRole('button', { name: 'emit cursor' }));
+
+  expect(onMarkdownChange).toHaveBeenCalledWith('user markdown');
+  expect(onCursorChange).toHaveBeenCalledWith({ line: 7, ch: 3 });
+});

--- a/Dev/Typedown.Editor/src/components/Editor/index.tsx
+++ b/Dev/Typedown.Editor/src/components/Editor/index.tsx
@@ -19,11 +19,15 @@ interface IEditorProps {
 }
 
 const Editor: React.FC<IEditorProps> = (props) => {
-    const [markdown, setMarkdown] = useState<string>(props.markdown);
-    const markdownRef = useRef<string>(props.markdown);
-    const [cursor, setCursor] = useState<any>(props.cursor);
-    const [options, setOptions] = useState<any>(props.options);
+    const { markdown: externalMarkdown, cursor: externalCursor, basePath, options: externalOptions, onMarkdownChange, onCursorChange } = props
+    const [markdown, setMarkdown] = useState<string>(externalMarkdown);
+    const markdownRef = useRef<string>(externalMarkdown);
+    const [cursor, setCursor] = useState<any>(externalCursor);
+    const cursorRef = useRef<any>(externalCursor);
+    const [options, setOptions] = useState<any>(externalOptions);
     const optionsRef = useRef<any>();
+    const skipMarkdownCallbackRef = useRef(false);
+    const skipCursorCallbackRef = useRef(true);
     const [searchOpen, setSearchOpen] = useState(0);
     const [searchArg, setSearchArg] = useState<{ value: string, opt: any }>();
     const muyaScrollTopRef = useRef(0);
@@ -40,33 +44,50 @@ const Editor: React.FC<IEditorProps> = (props) => {
     }, [options])
 
     useEffect(() => {
-        setOptions(props.options)
-    }, [props.options])
+        setOptions(externalOptions)
+    }, [externalOptions])
 
     useEffect(() => {
-        window.basePath = props.basePath ?? ''
-    }, [props.basePath])
+        window.basePath = basePath ?? ''
+    }, [basePath])
 
     useEffect(() => {
-        if (props.markdown != undefined && props.markdown !== markdownRef.current) {
-            markdownRef.current = props.markdown
-            setCursor(props.cursor)
-            setMarkdown(props.markdown)
+        if (externalMarkdown != undefined && externalMarkdown !== markdownRef.current) {
+            skipMarkdownCallbackRef.current = true
+            markdownRef.current = externalMarkdown
+            setMarkdown(externalMarkdown)
         }
-    }, [props.cursor, props.markdown])
+
+        if (externalCursor !== cursorRef.current) {
+            skipCursorCallbackRef.current = true
+            cursorRef.current = externalCursor
+            setCursor(externalCursor)
+        }
+    }, [externalCursor, externalMarkdown])
 
     useEffect(() => {
+        if (skipMarkdownCallbackRef.current) {
+            skipMarkdownCallbackRef.current = false
+            return
+        }
+
         if (markdown != undefined && markdownRef.current != markdown) {
-            props.onMarkdownChange?.(markdown)
             transport.postMessage('MarkdownChange', { text: markdown });
+            onMarkdownChange?.(markdown)
             markdownRef.current = markdown
         }
-    }, [markdown, props])
+    }, [markdown, onMarkdownChange])
 
     useEffect(() => {
-        props.onCursorChange?.(cursor)
+        if (skipCursorCallbackRef.current) {
+            skipCursorCallbackRef.current = false
+            return
+        }
+
+        cursorRef.current = cursor
+        onCursorChange?.(cursor)
         transport.postMessage('CursorChange', { cursor })
-    }, [cursor, props])
+    }, [cursor, onCursorChange])
 
     useEffect(() => transport.addListener<IExportArgs>('Export', async ({ type, context, basePath, title, options }) => {
         const generateOption = { printOptimization: false, title, toc: getHtmlToc(getTOC(markdownRef.current ?? '').toc), ...options }

--- a/Dev/Typedown.Editor/src/components/Editor/index.tsx
+++ b/Dev/Typedown.Editor/src/components/Editor/index.tsx
@@ -9,11 +9,20 @@ import { htmlToMarkdown } from "services/importHtml";
 import { DEFAULT_TURNDOWN_CONFIG } from "components/Muya/lib/config";
 import { getHtmlToc, getTOC } from "services/common";
 
-const Editor: React.FC = () => {
-    const [markdown, setMarkdown] = useState<string>();
-    const markdownRef = useRef<string>();
-    const [cursor, setCursor] = useState<any>();
-    const [options, setOptions] = useState<any>();
+interface IEditorProps {
+    markdown: string
+    cursor?: any
+    basePath: string | null
+    options: any
+    onMarkdownChange?: (markdown: string) => void
+    onCursorChange?: (cursor: any) => void
+}
+
+const Editor: React.FC<IEditorProps> = (props) => {
+    const [markdown, setMarkdown] = useState<string>(props.markdown);
+    const markdownRef = useRef<string>(props.markdown);
+    const [cursor, setCursor] = useState<any>(props.cursor);
+    const [options, setOptions] = useState<any>(props.options);
     const optionsRef = useRef<any>();
     const [searchOpen, setSearchOpen] = useState(0);
     const [searchArg, setSearchArg] = useState<{ value: string, opt: any }>();
@@ -23,13 +32,7 @@ const Editor: React.FC = () => {
     const OnFileLoaded = useCallback(() => setTimeout(() => transport.postMessage('FileLoaded', { text: markdownRef.current }), 100), [])
 
     useEffect(() => {
-        remote.getSettings().then(({ markdown, basePath, ...opt }: any) => {
-            window.basePath = basePath
-            setOptions(opt)
-            setMarkdown(markdown)
-            markdownRef.current = markdown
-            OnFileLoaded();
-        })
+        OnFileLoaded();
     }, [OnFileLoaded]);
 
     useEffect(() => {
@@ -37,15 +40,33 @@ const Editor: React.FC = () => {
     }, [options])
 
     useEffect(() => {
+        setOptions(props.options)
+    }, [props.options])
+
+    useEffect(() => {
+        window.basePath = props.basePath ?? ''
+    }, [props.basePath])
+
+    useEffect(() => {
+        if (props.markdown != undefined && props.markdown !== markdownRef.current) {
+            markdownRef.current = props.markdown
+            setCursor(props.cursor)
+            setMarkdown(props.markdown)
+        }
+    }, [props.cursor, props.markdown])
+
+    useEffect(() => {
         if (markdown != undefined && markdownRef.current != markdown) {
+            props.onMarkdownChange?.(markdown)
             transport.postMessage('MarkdownChange', { text: markdown });
             markdownRef.current = markdown
         }
-    }, [markdown])
+    }, [markdown, props])
 
     useEffect(() => {
+        props.onCursorChange?.(cursor)
         transport.postMessage('CursorChange', { cursor })
-    }, [cursor])
+    }, [cursor, props])
 
     useEffect(() => transport.addListener<IExportArgs>('Export', async ({ type, context, basePath, title, options }) => {
         const generateOption = { printOptimization: false, title, toc: getHtmlToc(getTOC(markdownRef.current ?? '').toc), ...options }
@@ -63,7 +84,7 @@ const Editor: React.FC = () => {
     }), [options]);
 
     useEffect(() => transport.addListener<{ text: string, basePath: string }>('LoadFile', ({ text, basePath }) => {
-        window.basePath = basePath
+        window.basePath = basePath ?? ''
         setCursor(undefined)
         setMarkdown(text)
         markdownRef.current = text
@@ -71,7 +92,7 @@ const Editor: React.FC = () => {
     }), [OnFileLoaded]);
 
     useEffect(() => transport.addListener<{ text: string, cursor: string, basePath: string }>('SetMarkdown', ({ text, cursor, basePath }) => {
-        window.basePath = basePath
+        window.basePath = basePath ?? ''
         setCursor(cursor)
         setTimeout(() => setMarkdown(text))
         markdownRef.current = text

--- a/Dev/Typedown.Editor/src/components/Tabs/DirtyCloseDialog.scss
+++ b/Dev/Typedown.Editor/src/components/Tabs/DirtyCloseDialog.scss
@@ -1,0 +1,79 @@
+.dirty-close-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.dirty-close-dialog {
+  background-color: var(--editor-bg, #1e1e1e);
+  border: 1px solid var(--editor-border, #333);
+  border-radius: 6px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  max-width: 400px;
+  width: calc(100vw - 48px);
+  padding: 20px 24px;
+  color: var(--editor-fg, #ccc);
+  outline: none;
+}
+
+.dirty-close-dialog__message {
+  margin: 0 0 20px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--editor-fg, #ccc);
+}
+
+.dirty-close-dialog__actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.dirty-close-dialog__button {
+  padding: 6px 16px;
+  font-size: 13px;
+  border-radius: 3px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  font-family: inherit;
+  outline: none;
+
+  &:focus-visible {
+    outline: 1px solid var(--themeColor, #007acc);
+    outline-offset: 1px;
+  }
+
+  &--save {
+    background-color: var(--themeColor, #007acc);
+    color: #fff;
+    border-color: var(--themeColor, #007acc);
+
+    &:hover {
+      opacity: 0.85;
+    }
+  }
+
+  &--dont-save {
+    background-color: transparent;
+    color: var(--editor-fg, #ccc);
+    border-color: var(--editor-border, #555);
+
+    &:hover {
+      background-color: var(--editor-tab-hover-bg, #383838);
+    }
+  }
+
+  &--cancel {
+    background-color: transparent;
+    color: var(--editor-fg, #ccc);
+    border-color: var(--editor-border, #555);
+
+    &:hover {
+      background-color: var(--editor-tab-hover-bg, #383838);
+    }
+  }
+}

--- a/Dev/Typedown.Editor/src/components/Tabs/DirtyCloseDialog.tsx
+++ b/Dev/Typedown.Editor/src/components/Tabs/DirtyCloseDialog.tsx
@@ -1,0 +1,69 @@
+import React, { useCallback } from 'react';
+import './DirtyCloseDialog.scss';
+
+interface DirtyCloseDialogProps {
+  tabName: string;
+  onSave: () => void;
+  onDontSave: () => void;
+  onCancel: () => void;
+}
+
+const DirtyCloseDialog: React.FC<DirtyCloseDialogProps> = ({
+  tabName,
+  onSave,
+  onDontSave,
+  onCancel,
+}) => {
+  const handleOverlayClick = useCallback((e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      onCancel();
+    }
+  }, [onCancel]);
+
+  return (
+    <div
+      className="dirty-close-overlay"
+      onClick={handleOverlayClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') {
+          onCancel();
+        }
+      }}
+    >
+      <div
+        aria-label="Unsaved changes"
+        className="dirty-close-dialog"
+        role="dialog"
+      >
+        <p className="dirty-close-dialog__message">
+          Save changes to &ldquo;{tabName}&rdquo; before closing?
+        </p>
+        <div className="dirty-close-dialog__actions">
+          <button
+            className="dirty-close-dialog__button dirty-close-dialog__button--save"
+            onClick={onSave}
+            type="button"
+          >
+            Save
+          </button>
+          <button
+            className="dirty-close-dialog__button dirty-close-dialog__button--dont-save"
+            onClick={onDontSave}
+            type="button"
+          >
+            Don&apos;t Save
+          </button>
+          <button
+            className="dirty-close-dialog__button dirty-close-dialog__button--cancel"
+            onClick={onCancel}
+            type="button"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DirtyCloseDialog;

--- a/Dev/Typedown.Editor/src/components/Tabs/TabBar.scss
+++ b/Dev/Typedown.Editor/src/components/Tabs/TabBar.scss
@@ -1,0 +1,120 @@
+.tab-bar {
+  display: flex;
+  align-items: stretch;
+  background-color: var(--editor-bg, #1e1e1e);
+  border-bottom: 1px solid var(--editor-border, #333);
+  height: 36px;
+  user-select: none;
+  flex-shrink: 0;
+}
+
+.tab-bar__tabs {
+  display: flex;
+  flex: 1;
+  overflow-x: auto;
+  overflow-y: hidden;
+
+  &::-webkit-scrollbar {
+    height: 0;
+    display: none;
+  }
+}
+
+.tab-bar__tab {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  height: 100%;
+  padding: 0 4px;
+  border-right: 1px solid var(--editor-border, #333);
+  background-color: var(--editor-tab-inactive-bg, #2d2d2d);
+  cursor: default;
+  transition: background-color 0.15s ease;
+
+  &--active {
+    background-color: var(--editor-bg, #1e1e1e);
+    border-bottom: 2px solid var(--themeColor, #007acc);
+  }
+
+  &:hover {
+    background-color: var(--editor-tab-hover-bg, #383838);
+  }
+
+  &--active:hover {
+    background-color: var(--editor-bg, #1e1e1e);
+  }
+}
+
+.tab-bar__tab-button {
+  background: none;
+  border: none;
+  color: var(--editor-fg, #ccc);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 0 8px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 180px;
+  line-height: 36px;
+  font-family: inherit;
+  outline: none;
+
+  &:focus-visible {
+    outline: 1px solid var(--themeColor, #007acc);
+    outline-offset: -2px;
+  }
+
+  .tab-bar__tab--active & {
+    color: var(--editor-fg-active, #fff);
+  }
+}
+
+.tab-bar__close-button {
+  background: none;
+  border: none;
+  color: var(--editor-fg, #999);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 0 4px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 3px;
+  flex-shrink: 0;
+  outline: none;
+
+  &:hover {
+    background-color: var(--editor-close-hover-bg, rgba(255, 255, 255, 0.1));
+    color: var(--editor-fg, #ccc);
+  }
+
+  &:focus-visible {
+    outline: 1px solid var(--themeColor, #007acc);
+  }
+}
+
+.tab-bar__new-button {
+  background: none;
+  border: none;
+  color: var(--editor-fg, #999);
+  cursor: pointer;
+  font-size: 18px;
+  padding: 0 12px;
+  line-height: 36px;
+  flex-shrink: 0;
+  outline: none;
+
+  &:hover {
+    background-color: var(--editor-tab-hover-bg, #383838);
+    color: var(--editor-fg, #ccc);
+  }
+
+  &:focus-visible {
+    outline: 1px solid var(--themeColor, #007acc);
+    outline-offset: -2px;
+  }
+}

--- a/Dev/Typedown.Editor/src/components/Tabs/TabBar.test.tsx
+++ b/Dev/Typedown.Editor/src/components/Tabs/TabBar.test.tsx
@@ -1,0 +1,307 @@
+// jsdom does not ship DataTransfer; provide a minimal polyfill for drag tests.
+class MockDataTransfer {
+  effectAllowed = 'none';
+  dropEffect = 'none';
+  private _data: Record<string, string> = {};
+
+  getData(format: string): string {
+    return this._data[format] ?? '';
+  }
+
+  setData(format: string, data: string): void {
+    this._data[format] = data;
+  }
+
+  clearData(): void {
+    this._data = {};
+  }
+}
+
+(globalThis as any).DataTransfer = MockDataTransfer;
+
+import React from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import TabBar from './TabBar';
+import type { TabDocument } from './tabModel';
+
+let tabIdCounter = 0;
+const makeTab = (overrides: Partial<TabDocument> = {}): TabDocument => ({
+  id: `tab-${++tabIdCounter}`,
+  path: null,
+  displayName: '\u672a\u547d\u540d',
+  text: '',
+  cursor: null,
+  basePath: null,
+  dirty: false,
+  ...overrides,
+});
+
+const getTabButtons = () =>
+  screen.queryAllByRole('tab') as HTMLButtonElement[];
+
+beforeEach(() => {
+  tabIdCounter = 0;
+});
+
+test('filename is visible and full path is exposed through the tab tooltip', () => {
+  const tabs = [
+    makeTab({ displayName: 'readme.md', path: 'c:\\projects\\docs\\readme.md' }),
+  ];
+  render(
+    <TabBar
+      tabs={tabs}
+      activeTabId={tabs[0].id}
+      onSelectTab={jest.fn()}
+      onCloseTab={jest.fn()}
+      onDirtyCloseSave={jest.fn()}
+      onDirtyCloseDontSave={jest.fn()}
+      onNewTab={jest.fn()}
+      onReorderTabs={jest.fn()}
+    />
+  );
+
+  const tabButton = getTabButtons()[0];
+  expect(tabButton).toHaveTextContent('readme.md');
+  expect(tabButton).toHaveAttribute('title', 'c:\\projects\\docs\\readme.md');
+});
+
+test('untitled documents show \u672a\u547d\u540d', () => {
+  const tab = makeTab();
+  render(
+    <TabBar
+      tabs={[tab]}
+      activeTabId={tab.id}
+      onSelectTab={jest.fn()}
+      onCloseTab={jest.fn()}
+      onDirtyCloseSave={jest.fn()}
+      onDirtyCloseDontSave={jest.fn()}
+      onNewTab={jest.fn()}
+      onReorderTabs={jest.fn()}
+    />
+  );
+
+  expect(screen.getByRole('tab')).toHaveTextContent('\u672a\u547d\u540d');
+});
+
+test('clicking a tab selects it', () => {
+  const onSelectTab = jest.fn();
+  const tabs = [makeTab({ displayName: 'a.md' }), makeTab({ displayName: 'b.md' })];
+  render(
+    <TabBar
+      tabs={tabs}
+      activeTabId={tabs[0].id}
+      onSelectTab={onSelectTab}
+      onCloseTab={jest.fn()}
+      onDirtyCloseSave={jest.fn()}
+      onDirtyCloseDontSave={jest.fn()}
+      onNewTab={jest.fn()}
+      onReorderTabs={jest.fn()}
+    />
+  );
+
+  fireEvent.click(screen.getByRole('tab', { name: 'b.md' }));
+  expect(onSelectTab).toHaveBeenCalledWith(tabs[1].id);
+});
+
+test('dragging a tab requests reorder', () => {
+  const onReorderTabs = jest.fn();
+  const tabs = [makeTab({ displayName: 'a.md' }), makeTab({ displayName: 'b.md' }), makeTab({ displayName: 'c.md' })];
+  render(
+    <TabBar
+      tabs={tabs}
+      activeTabId={tabs[0].id}
+      onSelectTab={jest.fn()}
+      onCloseTab={jest.fn()}
+      onDirtyCloseSave={jest.fn()}
+      onDirtyCloseDontSave={jest.fn()}
+      onNewTab={jest.fn()}
+      onReorderTabs={onReorderTabs}
+    />
+  );
+
+  const tabElements = getTabButtons();
+  const dragTab = tabElements[0];
+  const targetTab = tabElements[2];
+
+  const dt = new (globalThis as any).DataTransfer();
+  fireEvent.dragStart(dragTab, { dataTransfer: dt });
+  fireEvent.dragOver(targetTab, { dataTransfer: dt });
+  fireEvent.drop(targetTab, { dataTransfer: dt });
+
+  expect(onReorderTabs).toHaveBeenCalledWith(0, 2);
+});
+
+test('plus button requests a new untitled tab', () => {
+  const onNewTab = jest.fn();
+  render(
+    <TabBar
+      tabs={[makeTab()]}
+      activeTabId="tab-1"
+      onSelectTab={jest.fn()}
+      onCloseTab={jest.fn()}
+      onDirtyCloseSave={jest.fn()}
+      onDirtyCloseDontSave={jest.fn()}
+      onNewTab={onNewTab}
+      onReorderTabs={jest.fn()}
+    />
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: 'new tab' }));
+  expect(onNewTab).toHaveBeenCalled();
+});
+
+test('dirty close dialog shows exactly Save, Don\'t Save, and Cancel', () => {
+  const dirtyTab = makeTab({ displayName: 'dirty.md', dirty: true });
+  render(
+    <TabBar
+      tabs={[dirtyTab]}
+      activeTabId={dirtyTab.id}
+      onSelectTab={jest.fn()}
+      onCloseTab={jest.fn()}
+      onDirtyCloseSave={jest.fn()}
+      onDirtyCloseDontSave={jest.fn()}
+      onNewTab={jest.fn()}
+      onReorderTabs={jest.fn()}
+    />
+  );
+
+  const closeButton = screen.getByRole('button', { name: 'close dirty.md' });
+  fireEvent.click(closeButton);
+
+  const dialog = screen.getByRole('dialog');
+  expect(within(dialog).getByRole('button', { name: 'Save' })).toBeInTheDocument();
+  expect(within(dialog).getByRole('button', { name: "Don't Save" })).toBeInTheDocument();
+  expect(within(dialog).getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+});
+
+test('Cancel leaves the dialog state clean without invoking any close callback', () => {
+  const onDirtyCloseSave = jest.fn();
+  const onDirtyCloseDontSave = jest.fn();
+  const dirtyTab = makeTab({ displayName: 'dirty.md', dirty: true });
+  render(
+    <TabBar
+      tabs={[dirtyTab]}
+      activeTabId={dirtyTab.id}
+      onSelectTab={jest.fn()}
+      onCloseTab={jest.fn()}
+      onDirtyCloseSave={onDirtyCloseSave}
+      onDirtyCloseDontSave={onDirtyCloseDontSave}
+      onNewTab={jest.fn()}
+      onReorderTabs={jest.fn()}
+    />
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: 'close dirty.md' }));
+  const dialog = screen.getByRole('dialog');
+  fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  expect(onDirtyCloseSave).not.toHaveBeenCalled();
+  expect(onDirtyCloseDontSave).not.toHaveBeenCalled();
+});
+
+test('closing a clean tab invokes onCloseTab', () => {
+  const onCloseTab = jest.fn();
+  const cleanTab = makeTab({ displayName: 'clean.md', path: 'c:\\docs\\clean.md', dirty: false });
+  render(
+    <TabBar
+      tabs={[cleanTab]}
+      activeTabId={cleanTab.id}
+      onSelectTab={jest.fn()}
+      onCloseTab={onCloseTab}
+      onDirtyCloseSave={jest.fn()}
+      onDirtyCloseDontSave={jest.fn()}
+      onNewTab={jest.fn()}
+      onReorderTabs={jest.fn()}
+    />
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: 'close clean.md' }));
+  expect(onCloseTab).toHaveBeenCalledWith(cleanTab.id);
+});
+
+test('dirty indicator is shown on dirty tabs', () => {
+  const cleanTab = makeTab({ displayName: 'clean.md', dirty: false });
+  const dirtyTab = makeTab({ displayName: 'dirty.md', dirty: true });
+  render(
+    <TabBar
+      tabs={[cleanTab, dirtyTab]}
+      activeTabId={cleanTab.id}
+      onSelectTab={jest.fn()}
+      onCloseTab={jest.fn()}
+      onDirtyCloseSave={jest.fn()}
+      onDirtyCloseDontSave={jest.fn()}
+      onNewTab={jest.fn()}
+      onReorderTabs={jest.fn()}
+    />
+  );
+
+  const tabButtons = getTabButtons();
+  const dirtyBtn = tabButtons.find((btn) => btn.textContent === '* dirty.md');
+  const cleanBtn = tabButtons.find((btn) => btn.textContent === 'clean.md');
+  expect(dirtyBtn).toBeDefined();
+  expect(cleanBtn).toBeDefined();
+});
+
+test('active tab has aria-selected true', () => {
+  const tabs = [makeTab({ displayName: 'a.md' }), makeTab({ displayName: 'b.md' })];
+  render(
+    <TabBar
+      tabs={tabs}
+      activeTabId={tabs[0].id}
+      onSelectTab={jest.fn()}
+      onCloseTab={jest.fn()}
+      onDirtyCloseSave={jest.fn()}
+      onDirtyCloseDontSave={jest.fn()}
+      onNewTab={jest.fn()}
+      onReorderTabs={jest.fn()}
+    />
+  );
+
+  expect(screen.getByRole('tab', { name: 'a.md' })).toHaveAttribute('aria-selected', 'true');
+  expect(screen.getByRole('tab', { name: 'b.md' })).toHaveAttribute('aria-selected', 'false');
+});
+
+test('Save button in dirty dialog invokes onDirtyCloseSave', () => {
+  const onDirtyCloseSave = jest.fn();
+  const dirtyTab = makeTab({ displayName: 'dirty.md', dirty: true });
+  render(
+    <TabBar
+      tabs={[dirtyTab]}
+      activeTabId={dirtyTab.id}
+      onSelectTab={jest.fn()}
+      onCloseTab={jest.fn()}
+      onDirtyCloseSave={onDirtyCloseSave}
+      onDirtyCloseDontSave={jest.fn()}
+      onNewTab={jest.fn()}
+      onReorderTabs={jest.fn()}
+    />
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: 'close dirty.md' }));
+  fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+  expect(onDirtyCloseSave).toHaveBeenCalledWith(dirtyTab.id);
+});
+
+test('Don\'t Save button in dirty dialog invokes onDirtyCloseDontSave', () => {
+  const onDirtyCloseDontSave = jest.fn();
+  const dirtyTab = makeTab({ displayName: 'dirty.md', dirty: true });
+  render(
+    <TabBar
+      tabs={[dirtyTab]}
+      activeTabId={dirtyTab.id}
+      onSelectTab={jest.fn()}
+      onCloseTab={jest.fn()}
+      onDirtyCloseSave={jest.fn()}
+      onDirtyCloseDontSave={onDirtyCloseDontSave}
+      onNewTab={jest.fn()}
+      onReorderTabs={jest.fn()}
+    />
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: 'close dirty.md' }));
+  fireEvent.click(screen.getByRole('button', { name: "Don't Save" }));
+
+  expect(onDirtyCloseDontSave).toHaveBeenCalledWith(dirtyTab.id);
+});

--- a/Dev/Typedown.Editor/src/components/Tabs/TabBar.tsx
+++ b/Dev/Typedown.Editor/src/components/Tabs/TabBar.tsx
@@ -1,0 +1,145 @@
+import React, { useCallback, useState } from 'react';
+import DirtyCloseDialog from './DirtyCloseDialog';
+import type { TabDocument } from './tabModel';
+import './TabBar.scss';
+
+interface TabBarProps {
+  tabs: TabDocument[];
+  activeTabId: string | null;
+  onSelectTab: (tabId: string) => void;
+  onCloseTab: (tabId: string) => void;
+  onDirtyCloseSave: (tabId: string) => void;
+  onDirtyCloseDontSave: (tabId: string) => void;
+  onNewTab: () => void;
+  onReorderTabs: (fromIndex: number, toIndex: number) => void;
+}
+
+const TabBar: React.FC<TabBarProps> = ({
+  tabs,
+  activeTabId,
+  onSelectTab,
+  onCloseTab,
+  onDirtyCloseSave,
+  onDirtyCloseDontSave,
+  onNewTab,
+  onReorderTabs,
+}) => {
+  const [dirtyCloseTabId, setDirtyCloseTabId] = useState<string | null>(null);
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+
+  const handleClose = useCallback((tabId: string) => {
+    const tab = tabs.find((t) => t.id === tabId);
+    if (tab?.dirty) {
+      setDirtyCloseTabId(tabId);
+      return;
+    }
+    onCloseTab(tabId);
+  }, [tabs, onCloseTab]);
+
+  const handleDirtySave = useCallback(() => {
+    if (dirtyCloseTabId !== null) {
+      onDirtyCloseSave(dirtyCloseTabId);
+      setDirtyCloseTabId(null);
+    }
+  }, [dirtyCloseTabId, onDirtyCloseSave]);
+
+  const handleDirtyDontSave = useCallback(() => {
+    if (dirtyCloseTabId !== null) {
+      onDirtyCloseDontSave(dirtyCloseTabId);
+      setDirtyCloseTabId(null);
+    }
+  }, [dirtyCloseTabId, onDirtyCloseDontSave]);
+
+  const handleDirtyCancel = useCallback(() => {
+    setDirtyCloseTabId(null);
+  }, []);
+
+  const handleDragStart = useCallback((e: React.DragEvent, index: number) => {
+    setDragIndex(index);
+    e.dataTransfer.effectAllowed = 'move';
+    e.dataTransfer.setData('text/plain', String(index));
+  }, []);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    if (e.dataTransfer) {
+      e.dataTransfer.dropEffect = 'move';
+    }
+  }, []);
+
+  const handleDrop = useCallback((e: React.DragEvent, toIndex: number) => {
+    e.preventDefault();
+    if (dragIndex !== null && dragIndex !== toIndex) {
+      onReorderTabs(dragIndex, toIndex);
+    }
+    setDragIndex(null);
+  }, [dragIndex, onReorderTabs]);
+
+  const handleDragEnd = useCallback(() => {
+    setDragIndex(null);
+  }, []);
+
+  const dirtyTab = dirtyCloseTabId !== null
+    ? tabs.find((tab) => tab.id === dirtyCloseTabId)
+    : null;
+
+  return (
+    <div className="tab-bar">
+      <div className="tab-bar__tabs" role="tablist" aria-label="Tabs">
+        {tabs.map((tab, index) => {
+          const isActive = tab.id === activeTabId;
+          const label = tab.dirty ? `* ${tab.displayName}` : tab.displayName;
+
+          return (
+            <div
+              key={tab.id}
+              className={`tab-bar__tab${isActive ? ' tab-bar__tab--active' : ''}`}
+              draggable
+              onDragStart={(e) => handleDragStart(e, index)}
+              onDragOver={handleDragOver}
+              onDrop={(e) => handleDrop(e, index)}
+              onDragEnd={handleDragEnd}
+            >
+              <button
+                aria-selected={isActive}
+                className="tab-bar__tab-button"
+                onClick={() => onSelectTab(tab.id)}
+                role="tab"
+                title={tab.path ?? tab.displayName}
+                type="button"
+              >
+                {label}
+              </button>
+              <button
+                aria-label={`close ${tab.displayName}`}
+                className="tab-bar__close-button"
+                onClick={() => handleClose(tab.id)}
+                type="button"
+              >
+                ×
+              </button>
+            </div>
+          );
+        })}
+      </div>
+      <button
+        aria-label="new tab"
+        className="tab-bar__new-button"
+        onClick={onNewTab}
+        type="button"
+      >
+        +
+      </button>
+      {dirtyTab && (
+        <DirtyCloseDialog
+          tabName={dirtyTab.displayName}
+          onSave={handleDirtySave}
+          onDontSave={handleDirtyDontSave}
+          onCancel={handleDirtyCancel}
+        />
+      )}
+    </div>
+  );
+};
+
+export default TabBar;

--- a/Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.test.tsx
+++ b/Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.test.tsx
@@ -182,16 +182,13 @@ test('switching calls activateTab before loading the target document into the ed
 
   fireEvent.click(screen.getByText('start.md'));
 
-  await waitFor(() => expect(mockEventLog).toEqual(['activateTab', 'post:LoadFile']));
+  await waitFor(() => expect(mockEventLog).toEqual(['activateTab']));
   expect(mockActivateTab).toHaveBeenCalledWith({
     path: 'c:\\docs\\start.md',
     text: 'start markdown',
     dirty: false,
   });
-  expect(mockPostMessage).toHaveBeenCalledWith('LoadFile', {
-    text: 'start markdown',
-    basePath: 'c:\\docs',
-  });
+  expect(mockPostMessage).not.toHaveBeenCalledWith('LoadFile', expect.anything());
 });
 
 test('a failed saveTab call leaves the tab dirty and active', async () => {
@@ -204,6 +201,7 @@ test('a failed saveTab call leaves the tab dirty and active', async () => {
   await emit('SaveRequested', { saveAs: false });
 
   await waitFor(() => expect(mockSaveTab).toHaveBeenCalled());
+  expect(screen.getByText('* start.md')).toBeInTheDocument();
   expect(screen.getByText('* start.md').closest('button')).toHaveAttribute('aria-selected', 'true');
 });
 

--- a/Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.test.tsx
+++ b/Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.test.tsx
@@ -1,0 +1,228 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+type Listener = (args: any) => void;
+
+const mockListeners = new Map<string, Listener>();
+const mockEventLog: string[] = [];
+
+const mockGetSettings = jest.fn();
+const mockActivateTab = jest.fn();
+const mockSaveTab = jest.fn();
+const mockCloseWindow = jest.fn();
+const mockPostMessage = jest.fn();
+const mockPostMessageNoDiff = jest.fn();
+
+jest.mock('services/remote', () => ({
+  remote: {
+    getSettings: (...args: unknown[]) => mockGetSettings(...args),
+    activateTab: (...args: unknown[]) => mockActivateTab(...args),
+    saveTab: (...args: unknown[]) => mockSaveTab(...args),
+    closeWindow: (...args: unknown[]) => mockCloseWindow(...args),
+  },
+}));
+
+jest.mock('services/transport', () => ({
+  __esModule: true,
+  remoteFunction: jest.fn(),
+  default: {
+    addListener: (eventName: string, listener: Listener) => {
+      mockListeners.set(eventName, listener);
+      return () => {
+        mockListeners.delete(eventName);
+      };
+    },
+    postMessage: (...args: unknown[]) => {
+      mockEventLog.push(`post:${String(args[0])}`);
+      return mockPostMessage(...args);
+    },
+    postMessageNoDiff: (...args: unknown[]) => mockPostMessageNoDiff(...args),
+  },
+}));
+
+jest.mock('components/Editor', () => {
+  const MockEditor = ({
+    markdown,
+    basePath,
+    onMarkdownChange,
+    onCursorChange,
+  }: {
+    markdown: string;
+    basePath: string | null;
+    onMarkdownChange?: (markdown: string) => void;
+    onCursorChange?: (cursor: unknown) => void;
+  }) => (
+    <div>
+      <div data-testid="editor-instance">{markdown}</div>
+      <div data-testid="editor-base-path">{basePath ?? ''}</div>
+      <button onClick={() => onMarkdownChange?.('updated from editor')}>change markdown</button>
+      <button onClick={() => onCursorChange?.({ line: 3, ch: 9 })}>change cursor</button>
+    </div>
+  );
+
+  return {
+    __esModule: true,
+    default: MockEditor,
+  };
+});
+
+import TabCoordinator from './TabCoordinator';
+
+const getTabs = () => Array.from(document.querySelectorAll('[role="tab"]')) as HTMLButtonElement[];
+
+const emit = async (eventName: string, args: any) => {
+  const listener = mockListeners.get(eventName);
+  if (!listener) {
+    throw new Error(`Missing listener for ${eventName}`);
+  }
+  await act(async () => {
+    await listener(args);
+  });
+};
+
+beforeEach(() => {
+  mockListeners.clear();
+  mockEventLog.length = 0;
+  mockGetSettings.mockReset();
+  mockActivateTab.mockReset();
+  mockSaveTab.mockReset();
+  mockCloseWindow.mockReset();
+  mockPostMessage.mockClear();
+  mockPostMessageNoDiff.mockClear();
+  mockGetSettings.mockResolvedValue({
+    filePath: 'C:\\Docs\\start.md',
+    markdown: 'start markdown',
+    basePath: 'C:\\Docs',
+    sourceCode: false,
+    focusMode: false,
+    typewriter: false,
+  });
+  mockActivateTab.mockImplementation(async () => {
+    mockEventLog.push('activateTab');
+  });
+  mockSaveTab.mockResolvedValue({
+    path: 'C:\\Docs\\saved.md',
+    basePath: 'C:\\Docs',
+  });
+  mockCloseWindow.mockResolvedValue(undefined);
+});
+
+test('startup settings creates exactly one tab using filePath markdown and basePath', async () => {
+  render(<TabCoordinator />);
+
+  expect((await screen.findByText('start.md')).closest('button')).toHaveAttribute('title', 'c:\\docs\\start.md');
+  expect(getTabs()).toHaveLength(1);
+  expect(screen.getAllByTestId('editor-instance')).toHaveLength(1);
+  expect(screen.getByTestId('editor-instance')).toHaveTextContent('start markdown');
+  expect(screen.getByTestId('editor-base-path')).toHaveTextContent('c:\\docs');
+});
+
+test('DocumentLoaded opens a new tab or activates the existing canonical path', async () => {
+  render(<TabCoordinator />);
+  await screen.findByText('start.md');
+
+  await emit('DocumentLoaded', {
+    path: 'C:\\Docs\\Second.md',
+    text: 'second markdown',
+    basePath: 'C:\\Docs',
+    dirty: true,
+  });
+
+  expect((await screen.findByText('* second.md')).closest('button')).toHaveAttribute('aria-selected', 'true');
+  expect(getTabs()).toHaveLength(2);
+
+  await emit('DocumentLoaded', {
+    path: 'c:\\docs\\.\\second.md',
+    text: 'should not duplicate',
+    basePath: 'C:\\Docs',
+    dirty: false,
+  });
+
+  expect(getTabs()).toHaveLength(2);
+  expect(screen.getByText('* second.md').closest('button')).toHaveAttribute('aria-selected', 'true');
+});
+
+test('editor changes update only the active tab', async () => {
+  render(<TabCoordinator />);
+  await screen.findByText('start.md');
+
+  await emit('DocumentLoaded', {
+    path: 'C:\\Docs\\second.md',
+    text: 'second markdown',
+    basePath: 'C:\\Docs',
+    dirty: false,
+  });
+
+  await act(async () => {
+    fireEvent.click(screen.getByText('start.md'));
+  });
+  fireEvent.click(screen.getByRole('button', { name: 'change markdown' }));
+
+  fireEvent.click(screen.getByText('second.md'));
+  expect(screen.getByTestId('editor-instance')).toHaveTextContent('second markdown');
+
+  fireEvent.click(screen.getByText('* start.md'));
+  expect(screen.getByTestId('editor-instance')).toHaveTextContent('updated from editor');
+});
+
+test('switching calls activateTab before loading the target document into the editor', async () => {
+  render(<TabCoordinator />);
+  await screen.findByText('start.md');
+
+  await emit('DocumentLoaded', {
+    path: 'C:\\Docs\\second.md',
+    text: 'second markdown',
+    basePath: 'C:\\Docs',
+    dirty: false,
+  });
+  fireEvent.click(screen.getByRole('button', { name: 'change markdown' }));
+  mockEventLog.length = 0;
+  mockActivateTab.mockClear();
+  mockPostMessage.mockClear();
+
+  fireEvent.click(screen.getByText('start.md'));
+
+  await waitFor(() => expect(mockEventLog).toEqual(['activateTab', 'post:LoadFile']));
+  expect(mockActivateTab).toHaveBeenCalledWith({
+    path: 'c:\\docs\\start.md',
+    text: 'start markdown',
+    dirty: false,
+  });
+  expect(mockPostMessage).toHaveBeenCalledWith('LoadFile', {
+    text: 'start markdown',
+    basePath: 'c:\\docs',
+  });
+});
+
+test('a failed saveTab call leaves the tab dirty and active', async () => {
+  mockSaveTab.mockResolvedValueOnce(null);
+
+  render(<TabCoordinator />);
+  await screen.findByText('start.md');
+
+  fireEvent.click(screen.getByRole('button', { name: 'change markdown' }));
+  await emit('SaveRequested', { saveAs: false });
+
+  await waitFor(() => expect(mockSaveTab).toHaveBeenCalled());
+  expect(screen.getByText('* start.md').closest('button')).toHaveAttribute('aria-selected', 'true');
+});
+
+test('NewTabRequested creates an untitled tab without replacing existing tabs', async () => {
+  render(<TabCoordinator />);
+  await screen.findByText('start.md');
+
+  await emit('NewTabRequested', undefined);
+
+  expect((await screen.findByText('未命名')).closest('button')).toHaveAttribute('aria-selected', 'true');
+  expect(getTabs()).toHaveLength(2);
+  expect(screen.getByText('start.md')).toBeInTheDocument();
+});
+
+test('CloseWindow is called only after the last tab is closed without pending dirty work', async () => {
+  render(<TabCoordinator />);
+  await screen.findByText('start.md');
+
+  fireEvent.click(screen.getByRole('button', { name: 'close start.md' }));
+
+  await waitFor(() => expect(mockCloseWindow).toHaveBeenCalledTimes(1));
+});

--- a/Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.tsx
+++ b/Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Editor from 'components/Editor';
+import TabBar from './TabBar';
 import { remote } from 'services/remote';
 import transport from 'services/transport';
 import {
@@ -12,6 +13,7 @@ import {
   createUntitledTab,
   openDocument,
   markTabSaved,
+  reorderTabs,
   switchTab,
   type TabDocument,
   type TabState,
@@ -202,13 +204,10 @@ const TabCoordinator: React.FC = () => {
     }));
   }), []);
 
-  const handleClose = useCallback(async (tabId: string) => {
-    const currentState = tabStateRef.current;
-    const targetTab = currentState.tabs.find((tab) => tab.id === tabId);
-    if (!targetTab || targetTab.dirty) {
-      return;
-    }
+  // --- tab-bar handlers ---
 
+  const handleCloseClean = useCallback(async (tabId: string) => {
+    const currentState = tabStateRef.current;
     const result = closeTab(currentState, tabId, 'dont-save');
     setTabState(result.nextState);
 
@@ -217,11 +216,62 @@ const TabCoordinator: React.FC = () => {
       return;
     }
 
-    const nextActiveTab = getActiveTab(result.nextState);
-    if (nextActiveTab && nextActiveTab.id !== targetTab.id) {
+    const nextActiveTab = result.nextState.tabs.find((tab) => tab.id === result.nextState.activeTabId);
+    if (nextActiveTab) {
       activateTab(nextActiveTab);
     }
   }, [activateTab]);
+
+  const handleDirtyCloseSave = useCallback(async (tabId: string) => {
+    const currentState = tabStateRef.current;
+    const targetTab = currentState.tabs.find((tab) => tab.id === tabId);
+    if (!targetTab) {
+      return;
+    }
+
+    const saveResult = await remote.saveTab(buildSaveTabPayload(targetTab.path, targetTab.text, false));
+    if (!isConfirmedSaveResult(saveResult)) {
+      return;
+    }
+
+    const result = closeTab(currentState, tabId, 'save', {
+      success: true,
+      path: saveResult.path,
+    });
+    setTabState(result.nextState);
+
+    if (result.shouldCloseWindow) {
+      await remote.closeWindow();
+      return;
+    }
+
+    const nextActiveTab = result.nextState.tabs.find((tab) => tab.id === result.nextState.activeTabId);
+    if (nextActiveTab) {
+      activateTab(nextActiveTab);
+    }
+  }, [activateTab]);
+
+  const handleDirtyCloseDontSave = useCallback(async (tabId: string) => {
+    const currentState = tabStateRef.current;
+    const result = closeTab(currentState, tabId, 'dont-save');
+    setTabState(result.nextState);
+
+    if (result.shouldCloseWindow) {
+      await remote.closeWindow();
+      return;
+    }
+
+    const nextActiveTab = result.nextState.tabs.find((tab) => tab.id === result.nextState.activeTabId);
+    if (nextActiveTab) {
+      activateTab(nextActiveTab);
+    }
+  }, [activateTab]);
+
+  const handleReorderTabs = useCallback((fromIndex: number, toIndex: number) => {
+    setTabState((state) => reorderTabs(state, fromIndex, toIndex));
+  }, []);
+
+  // --- render ---
 
   const activeTab = useMemo(() => getActiveTab(tabState), [tabState]);
 
@@ -230,46 +280,17 @@ const TabCoordinator: React.FC = () => {
   }
 
   return (
-    <div>
-      <div aria-label="Tabs" role="tablist">
-        {tabState.tabs.map((tab) => {
-          const label = `${tab.dirty ? '* ' : ''}${tab.displayName}`;
-
-          return (
-            <span key={tab.id}>
-              <button
-                aria-selected={tab.id === tabState.activeTabId}
-                onClick={() => {
-                  void handleTabSwitch(tab.id);
-                }}
-                role="tab"
-                title={tab.path ?? tab.displayName}
-                type="button"
-              >
-                {label}
-              </button>
-              <button
-                aria-label={`close ${tab.displayName}`}
-                onClick={() => {
-                  void handleClose(tab.id);
-                }}
-                type="button"
-              >
-                ×
-              </button>
-            </span>
-          );
-        })}
-      </div>
-      <button
-        aria-label="new tab"
-        onClick={() => {
-          void handleNewTab();
-        }}
-        type="button"
-      >
-        +
-      </button>
+    <div className="app-layout">
+      <TabBar
+        activeTabId={tabState.activeTabId}
+        onCloseTab={handleCloseClean}
+        onDirtyCloseDontSave={handleDirtyCloseDontSave}
+        onDirtyCloseSave={handleDirtyCloseSave}
+        onNewTab={() => { void handleNewTab(); }}
+        onReorderTabs={handleReorderTabs}
+        onSelectTab={(tabId) => { void handleTabSwitch(tabId); }}
+        tabs={tabState.tabs}
+      />
       <Editor
         basePath={activeTab.basePath}
         cursor={activeTab.cursor}

--- a/Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.tsx
+++ b/Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.tsx
@@ -1,0 +1,289 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Editor from 'components/Editor';
+import { remote } from 'services/remote';
+import transport from 'services/transport';
+import {
+  buildActivateTabPayload,
+  buildSaveTabPayload,
+  isConfirmedSaveResult,
+} from 'services/remote/common';
+import {
+  closeTab,
+  createUntitledTab,
+  openDocument,
+  markTabSaved,
+  switchTab,
+  type TabDocument,
+  type TabState,
+} from './tabModel';
+
+interface StartupSettings {
+  filePath: string | null;
+  markdown: string;
+  basePath: string | null;
+  [key: string]: unknown;
+}
+
+interface DocumentLoadedArgs {
+  path: string;
+  text: string;
+  basePath: string | null;
+  dirty: boolean;
+}
+
+interface NewTabRequestedArgs {
+  text?: string;
+  basePath?: string | null;
+  dirty?: boolean;
+}
+
+interface SaveRequestedArgs {
+  saveAs?: boolean;
+}
+
+const DEFAULT_NEW_TAB_MARKDOWN = '\n';
+
+const createStartupState = ({ filePath, markdown, basePath }: StartupSettings): TabState => {
+  if (filePath) {
+    return openDocument({ tabs: [], activeTabId: null }, {
+      path: filePath,
+      text: markdown,
+      basePath,
+    });
+  }
+
+  const tab = {
+    ...createUntitledTab(),
+    text: markdown,
+    basePath,
+  };
+
+  return {
+    tabs: [tab],
+    activeTabId: tab.id,
+  };
+};
+
+const getActiveTab = (state: TabState): TabDocument | undefined => (
+  state.tabs.find((tab) => tab.id === state.activeTabId)
+);
+
+const TabCoordinator: React.FC = () => {
+  const [editorOptions, setEditorOptions] = useState<Record<string, unknown>>();
+  const [tabState, setTabState] = useState<TabState>({ tabs: [], activeTabId: null });
+  const tabStateRef = useRef(tabState);
+
+  useEffect(() => {
+    tabStateRef.current = tabState;
+  }, [tabState]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    remote.getSettings().then((settings: unknown) => {
+      if (cancelled) {
+        return;
+      }
+
+      const { markdown, filePath, basePath, ...options } = settings as StartupSettings;
+      setEditorOptions(options);
+      setTabState(createStartupState({
+        markdown,
+        filePath,
+        basePath,
+      }));
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const activateAndLoad = useCallback((tab: TabDocument) => {
+    void remote.activateTab(buildActivateTabPayload(tab.path, tab.text, tab.dirty));
+    transport.postMessage('LoadFile', {
+      text: tab.text,
+      basePath: tab.basePath,
+    });
+  }, []);
+
+  const handleTabSwitch = useCallback((tabId: string) => {
+    const currentState = tabStateRef.current;
+    const targetTab = currentState.tabs.find((tab) => tab.id === tabId);
+    if (!targetTab || targetTab.id === currentState.activeTabId) {
+      return;
+    }
+
+    setTabState((state) => switchTab(state, tabId));
+    activateAndLoad(targetTab);
+  }, [activateAndLoad]);
+
+  const handleMarkdownChange = useCallback((markdown: string) => {
+    setTabState((state) => ({
+      ...state,
+      tabs: state.tabs.map((tab) => (
+        tab.id === state.activeTabId
+          ? { ...tab, text: markdown, dirty: true }
+          : tab
+      )),
+    }));
+  }, []);
+
+  const handleCursorChange = useCallback((cursor: unknown) => {
+    setTabState((state) => ({
+      ...state,
+      tabs: state.tabs.map((tab) => (
+        tab.id === state.activeTabId
+          ? { ...tab, cursor }
+          : tab
+      )),
+    }));
+  }, []);
+
+  const handleNewTab = useCallback((args?: NewTabRequestedArgs) => {
+    const tab = {
+      ...createUntitledTab(),
+      text: args?.text ?? DEFAULT_NEW_TAB_MARKDOWN,
+      basePath: args?.basePath ?? null,
+      dirty: args?.dirty ?? false,
+    };
+
+    setTabState((state) => ({
+      tabs: [...state.tabs, tab],
+      activeTabId: tab.id,
+    }));
+
+    activateAndLoad(tab);
+  }, [activateAndLoad]);
+
+  useEffect(() => transport.addListener<DocumentLoadedArgs>('DocumentLoaded', (document) => {
+    const currentState = tabStateRef.current;
+    const nextState = openDocument(currentState, {
+      path: document.path,
+      text: document.text,
+      basePath: document.basePath,
+      cursor: null,
+    });
+    const targetTab = getActiveTab(nextState);
+    if (!targetTab) {
+      return;
+    }
+
+    const normalizedState = document.dirty
+      ? {
+        ...nextState,
+        tabs: nextState.tabs.map((tab) => (
+          tab.id === targetTab.id ? { ...tab, dirty: true } : tab
+        )),
+      }
+      : nextState;
+
+    setTabState(normalizedState);
+    const activeDocument = getActiveTab(normalizedState);
+    if (activeDocument) {
+      activateAndLoad(activeDocument);
+    }
+  }), [activateAndLoad]);
+
+  useEffect(() => transport.addListener<NewTabRequestedArgs | undefined>('NewTabRequested', (args) => {
+    void handleNewTab(args);
+  }), [handleNewTab]);
+
+  useEffect(() => transport.addListener<SaveRequestedArgs | undefined>('SaveRequested', async (args) => {
+    const activeTab = getActiveTab(tabStateRef.current);
+    if (!activeTab) {
+      return;
+    }
+
+    const result = await remote.saveTab(buildSaveTabPayload(activeTab.path, activeTab.text, args?.saveAs === true));
+    if (!isConfirmedSaveResult(result)) {
+      return;
+    }
+
+    setTabState((state) => markTabSaved(state, activeTab.id, {
+      success: true,
+      path: result.path,
+    }));
+  }), []);
+
+  const handleClose = useCallback(async (tabId: string) => {
+    const currentState = tabStateRef.current;
+    const targetTab = currentState.tabs.find((tab) => tab.id === tabId);
+    if (!targetTab || targetTab.dirty) {
+      return;
+    }
+
+    const result = closeTab(currentState, tabId, 'dont-save');
+    setTabState(result.nextState);
+
+    if (result.shouldCloseWindow) {
+      await remote.closeWindow();
+      return;
+    }
+
+    const nextActiveTab = getActiveTab(result.nextState);
+    if (nextActiveTab && nextActiveTab.id !== targetTab.id) {
+      activateAndLoad(nextActiveTab);
+    }
+  }, [activateAndLoad]);
+
+  const activeTab = useMemo(() => getActiveTab(tabState), [tabState]);
+
+  if (!editorOptions || !activeTab) {
+    return null;
+  }
+
+  return (
+    <div>
+      <div aria-label="Tabs" role="tablist">
+        {tabState.tabs.map((tab) => {
+          const label = `${tab.dirty ? '* ' : ''}${tab.displayName}`;
+
+          return (
+            <span key={tab.id}>
+              <button
+                aria-selected={tab.id === tabState.activeTabId}
+                onClick={() => {
+                  void handleTabSwitch(tab.id);
+                }}
+                role="tab"
+                title={tab.path ?? tab.displayName}
+                type="button"
+              >
+                {label}
+              </button>
+              <button
+                aria-label={`close ${tab.displayName}`}
+                onClick={() => {
+                  void handleClose(tab.id);
+                }}
+                type="button"
+              >
+                ×
+              </button>
+            </span>
+          );
+        })}
+      </div>
+      <button
+        aria-label="new tab"
+        onClick={() => {
+          void handleNewTab();
+        }}
+        type="button"
+      >
+        +
+      </button>
+      <Editor
+        basePath={activeTab.basePath}
+        cursor={activeTab.cursor}
+        markdown={activeTab.text}
+        onCursorChange={handleCursorChange}
+        onMarkdownChange={handleMarkdownChange}
+        options={editorOptions}
+      />
+    </div>
+  );
+};
+
+export default TabCoordinator;

--- a/Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.tsx
+++ b/Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.tsx
@@ -99,12 +99,8 @@ const TabCoordinator: React.FC = () => {
     };
   }, []);
 
-  const activateAndLoad = useCallback((tab: TabDocument) => {
+  const activateTab = useCallback((tab: TabDocument) => {
     void remote.activateTab(buildActivateTabPayload(tab.path, tab.text, tab.dirty));
-    transport.postMessage('LoadFile', {
-      text: tab.text,
-      basePath: tab.basePath,
-    });
   }, []);
 
   const handleTabSwitch = useCallback((tabId: string) => {
@@ -115,8 +111,8 @@ const TabCoordinator: React.FC = () => {
     }
 
     setTabState((state) => switchTab(state, tabId));
-    activateAndLoad(targetTab);
-  }, [activateAndLoad]);
+    activateTab(targetTab);
+  }, [activateTab]);
 
   const handleMarkdownChange = useCallback((markdown: string) => {
     setTabState((state) => ({
@@ -153,8 +149,8 @@ const TabCoordinator: React.FC = () => {
       activeTabId: tab.id,
     }));
 
-    activateAndLoad(tab);
-  }, [activateAndLoad]);
+    activateTab(tab);
+  }, [activateTab]);
 
   useEffect(() => transport.addListener<DocumentLoadedArgs>('DocumentLoaded', (document) => {
     const currentState = tabStateRef.current;
@@ -181,9 +177,9 @@ const TabCoordinator: React.FC = () => {
     setTabState(normalizedState);
     const activeDocument = getActiveTab(normalizedState);
     if (activeDocument) {
-      activateAndLoad(activeDocument);
+      activateTab(activeDocument);
     }
-  }), [activateAndLoad]);
+  }), [activateTab]);
 
   useEffect(() => transport.addListener<NewTabRequestedArgs | undefined>('NewTabRequested', (args) => {
     void handleNewTab(args);
@@ -223,9 +219,9 @@ const TabCoordinator: React.FC = () => {
 
     const nextActiveTab = getActiveTab(result.nextState);
     if (nextActiveTab && nextActiveTab.id !== targetTab.id) {
-      activateAndLoad(nextActiveTab);
+      activateTab(nextActiveTab);
     }
-  }, [activateAndLoad]);
+  }, [activateTab]);
 
   const activeTab = useMemo(() => getActiveTab(tabState), [tabState]);
 

--- a/Dev/Typedown.Editor/src/components/Tabs/tabModel.test.ts
+++ b/Dev/Typedown.Editor/src/components/Tabs/tabModel.test.ts
@@ -14,6 +14,20 @@ const createState = (...tabs: ReturnType<typeof createUntitledTab>[]) => ({
   activeTabId: tabs[0]?.id ?? null,
 });
 
+const loadRemoteCommon = () => {
+  jest.resetModules();
+  Object.defineProperty(window, 'chrome', {
+    configurable: true,
+    value: {
+      webview: {
+        addEventListener: jest.fn(),
+        postMessage: jest.fn(),
+      },
+    },
+  });
+  return require('../../services/remote/common') as typeof import('../../services/remote/common');
+};
+
 test('canonicalizePath normalizes Windows casing and redundant segments', () => {
   expect(canonicalizePath('C:\\Docs\\Folder\\..\\Draft.md')).toBe('c:\\docs\\draft.md');
 });
@@ -30,6 +44,47 @@ test('createUntitledTab creates unique untitled tabs with clean state', () => {
   expect(first.path).toBeNull();
   expect(first.displayName).toBe('\u672a\u547d\u540d');
   expect(first.dirty).toBe(false);
+});
+
+test('buildActivateTabPayload keeps the nullable path current text and dirty flag', () => {
+  const { buildActivateTabPayload } = loadRemoteCommon();
+
+  expect(buildActivateTabPayload(null, 'draft', true)).toEqual({
+    path: null,
+    text: 'draft',
+    dirty: true,
+  });
+});
+
+test('buildSaveTabPayload keeps the nullable path current text and saveAs flag', () => {
+  const { buildSaveTabPayload } = loadRemoteCommon();
+
+  expect(buildSaveTabPayload('C:\\Docs\\Draft.md', 'draft', false)).toEqual({
+    path: 'C:\\Docs\\Draft.md',
+    text: 'draft',
+    saveAs: false,
+  });
+});
+
+test('unconfirmed save results are rejected so React keeps the tab dirty', () => {
+  const { isConfirmedSaveResult } = loadRemoteCommon();
+  const tab = {
+    ...createUntitledTab(),
+    text: 'draft',
+    dirty: true,
+    path: null,
+    displayName: '未命名',
+    basePath: null,
+  };
+  const state = createState(tab);
+  const unconfirmedResult = { basePath: 'C:\\Docs' };
+
+  const nextState = isConfirmedSaveResult(unconfirmedResult)
+    ? markTabSaved(state, tab.id, { success: true, path: unconfirmedResult.path })
+    : state;
+
+  expect(isConfirmedSaveResult(unconfirmedResult)).toBe(false);
+  expect(nextState).toEqual(state);
 });
 
 test('openDocument reuses the existing tab when the path only differs by case or segments', () => {

--- a/Dev/Typedown.Editor/src/components/Tabs/tabModel.test.ts
+++ b/Dev/Typedown.Editor/src/components/Tabs/tabModel.test.ts
@@ -18,6 +18,10 @@ test('canonicalizePath normalizes Windows casing and redundant segments', () => 
   expect(canonicalizePath('C:\\Docs\\Folder\\..\\Draft.md')).toBe('c:\\docs\\draft.md');
 });
 
+test('canonicalizePath preserves UNC roots while normalizing redundant segments', () => {
+  expect(canonicalizePath('\\\\Server\\Share\\Folder\\..\\File.md')).toBe('\\\\server\\share\\file.md');
+});
+
 test('createUntitledTab creates unique untitled tabs with clean state', () => {
   const first = createUntitledTab();
   const second = createUntitledTab();
@@ -136,6 +140,46 @@ test('markTabSaved updates path name and base path only after a successful save 
     path: 'c:\\docs\\saved.md',
     displayName: 'saved.md',
     basePath: 'c:\\docs',
+    dirty: false,
+  });
+});
+
+test('markTabSaved keeps drive root as the base path for files at the drive root', () => {
+  const tab = {
+    ...createUntitledTab(),
+    dirty: true,
+  };
+  const state = createState(tab);
+
+  const saved = markTabSaved(state, tab.id, {
+    success: true,
+    path: 'C:\\File.md',
+  });
+
+  expect(saved.tabs[0]).toMatchObject({
+    path: 'c:\\file.md',
+    displayName: 'file.md',
+    basePath: 'c:\\',
+    dirty: false,
+  });
+});
+
+test('markTabSaved keeps the UNC share root as the base path for files at the share root', () => {
+  const tab = {
+    ...createUntitledTab(),
+    dirty: true,
+  };
+  const state = createState(tab);
+
+  const saved = markTabSaved(state, tab.id, {
+    success: true,
+    path: '\\\\Server\\Share\\File.md',
+  });
+
+  expect(saved.tabs[0]).toMatchObject({
+    path: '\\\\server\\share\\file.md',
+    displayName: 'file.md',
+    basePath: '\\\\server\\share',
     dirty: false,
   });
 });

--- a/Dev/Typedown.Editor/src/components/Tabs/tabModel.test.ts
+++ b/Dev/Typedown.Editor/src/components/Tabs/tabModel.test.ts
@@ -1,0 +1,205 @@
+import {
+  canonicalizePath,
+  closeTab,
+  createUntitledTab,
+  markTabSaved,
+  openDocument,
+  reorderTabs,
+  switchTab,
+  updateTabText,
+} from './tabModel';
+
+const createState = (...tabs: ReturnType<typeof createUntitledTab>[]) => ({
+  tabs,
+  activeTabId: tabs[0]?.id ?? null,
+});
+
+test('canonicalizePath normalizes Windows casing and redundant segments', () => {
+  expect(canonicalizePath('C:\\Docs\\Folder\\..\\Draft.md')).toBe('c:\\docs\\draft.md');
+});
+
+test('createUntitledTab creates unique untitled tabs with clean state', () => {
+  const first = createUntitledTab();
+  const second = createUntitledTab();
+
+  expect(first.id).not.toBe(second.id);
+  expect(first.path).toBeNull();
+  expect(first.displayName).toBe('\u672a\u547d\u540d');
+  expect(first.dirty).toBe(false);
+});
+
+test('openDocument reuses the existing tab when the path only differs by case or segments', () => {
+  const firstOpen = openDocument(createState(), {
+    path: 'C:\\Docs\\Folder\\..\\Draft.md',
+    text: 'first',
+    cursor: { line: 1, ch: 2 },
+    basePath: 'C:\\Docs',
+  });
+
+  const reopened = openDocument(firstOpen, {
+    path: 'c:\\docs\\.\\draft.md',
+    text: 'second',
+    cursor: { line: 8, ch: 9 },
+    basePath: 'C:\\Docs',
+  });
+
+  expect(reopened.tabs).toHaveLength(1);
+  expect(reopened.activeTabId).toBe(firstOpen.activeTabId);
+  expect(reopened.tabs[0].path).toBe('c:\\docs\\draft.md');
+  expect(reopened.tabs[0].text).toBe('first');
+  expect(reopened.tabs[0].cursor).toEqual({ line: 1, ch: 2 });
+  expect(reopened.tabs[0].basePath).toBe('c:\\docs');
+});
+
+test('updateTabText changes only the selected tab and marks it dirty', () => {
+  const first = {
+    ...createUntitledTab(),
+    text: 'first',
+    cursor: { line: 1, ch: 2 },
+    basePath: 'c:\\docs',
+  };
+  const second = {
+    ...createUntitledTab(),
+    text: 'second',
+    cursor: { line: 3, ch: 4 },
+    basePath: 'c:\\docs',
+  };
+  const state = createState(first, second);
+
+  const next = updateTabText(state, first.id, 'updated');
+
+  expect(next.tabs[0].text).toBe('updated');
+  expect(next.tabs[0].dirty).toBe(true);
+  expect(next.tabs[1].text).toBe('second');
+  expect(next.tabs[1].dirty).toBe(false);
+});
+
+test('switchTab keeps each tab text cursor and base path unchanged', () => {
+  const first = {
+    ...createUntitledTab(),
+    text: 'first',
+    cursor: { line: 1, ch: 2 },
+    basePath: 'c:\\docs\\one',
+  };
+  const second = {
+    ...createUntitledTab(),
+    text: 'second',
+    cursor: { line: 3, ch: 4 },
+    basePath: 'c:\\docs\\two',
+  };
+  const state = createState(first, second);
+
+  const next = switchTab(state, second.id);
+
+  expect(next.activeTabId).toBe(second.id);
+  expect(next.tabs).toEqual(state.tabs);
+});
+
+test('reorderTabs moves one tab without changing the active tab or contents', () => {
+  const first = { ...createUntitledTab(), text: 'first', cursor: { line: 1, ch: 2 }, basePath: 'c:\\docs' };
+  const second = { ...createUntitledTab(), text: 'second', cursor: { line: 3, ch: 4 }, basePath: 'c:\\docs' };
+  const third = { ...createUntitledTab(), text: 'third', cursor: { line: 5, ch: 6 }, basePath: 'c:\\docs' };
+  const state = { tabs: [first, second, third], activeTabId: second.id };
+
+  const next = reorderTabs(state, 0, 2);
+
+  expect(next.activeTabId).toBe(second.id);
+  expect(next.tabs.map((tab) => tab.id)).toEqual([second.id, third.id, first.id]);
+  expect(next.tabs.map((tab) => tab.text)).toEqual(['second', 'third', 'first']);
+});
+
+test('markTabSaved updates path name and base path only after a successful save result', () => {
+  const tab = {
+    ...createUntitledTab(),
+    text: 'draft',
+    dirty: true,
+    path: 'c:\\docs\\draft.md',
+    displayName: 'Draft',
+    basePath: 'c:\\docs',
+    cursor: { line: 1, ch: 2 },
+  };
+  const state = createState(tab);
+
+  const failed = markTabSaved(state, tab.id, {
+    success: false,
+    path: 'C:\\Docs\\Saved.md',
+  });
+
+  expect(failed).toEqual(state);
+
+  const saved = markTabSaved(state, tab.id, {
+    success: true,
+    path: 'C:\\Docs\\Saved.md',
+  });
+
+  expect(saved.tabs[0]).toMatchObject({
+    path: 'c:\\docs\\saved.md',
+    displayName: 'saved.md',
+    basePath: 'c:\\docs',
+    dirty: false,
+  });
+});
+
+test('closeTab returns the expected state for save dont-save and cancel', () => {
+  const first = {
+    ...createUntitledTab(),
+    text: 'first',
+    dirty: true,
+    path: 'c:\\docs\\first.md',
+    displayName: 'first.md',
+    basePath: 'c:\\docs',
+  };
+  const second = {
+    ...createUntitledTab(),
+    text: 'second',
+    dirty: false,
+    path: 'c:\\docs\\second.md',
+    displayName: 'second.md',
+    basePath: 'c:\\docs',
+  };
+  const state = { tabs: [first, second], activeTabId: first.id };
+
+  const cancel = closeTab(state, first.id, 'cancel');
+  expect(cancel.decision).toBe('cancel');
+  expect(cancel.shouldCloseWindow).toBe(false);
+  expect(cancel.nextState).toBe(state);
+
+  const dontSave = closeTab(state, first.id, 'dont-save');
+  expect(dontSave.decision).toBe('dont-save');
+  expect(dontSave.shouldCloseWindow).toBe(false);
+  expect(dontSave.nextState.tabs.map((tab) => tab.id)).toEqual([second.id]);
+  expect(dontSave.nextState.activeTabId).toBe(second.id);
+
+  const save = closeTab(state, first.id, 'save', {
+    success: true,
+    path: 'C:\\Docs\\Saved.md',
+  });
+  expect(save.decision).toBe('save');
+  expect(save.shouldCloseWindow).toBe(false);
+  expect(save.nextState.tabs.map((tab) => tab.id)).toEqual([second.id]);
+  expect(save.nextState.activeTabId).toBe(second.id);
+  expect(save.nextState.tabs[0]).toMatchObject({
+    path: 'c:\\docs\\second.md',
+    displayName: 'second.md',
+    basePath: 'c:\\docs',
+    dirty: false,
+  });
+});
+
+test('closeTab reports shouldCloseWindow when closing the last tab', () => {
+  const tab = {
+    ...createUntitledTab(),
+    text: 'only',
+    dirty: false,
+    path: 'c:\\docs\\only.md',
+    displayName: 'only.md',
+    basePath: 'c:\\docs',
+  };
+  const state = { tabs: [tab], activeTabId: tab.id };
+
+  const decision = closeTab(state, tab.id, 'dont-save');
+
+  expect(decision.shouldCloseWindow).toBe(true);
+  expect(decision.nextState.tabs).toHaveLength(0);
+  expect(decision.nextState.activeTabId).toBeNull();
+});

--- a/Dev/Typedown.Editor/src/components/Tabs/tabModel.ts
+++ b/Dev/Typedown.Editor/src/components/Tabs/tabModel.ts
@@ -37,20 +37,16 @@ const UNTITLED_NAME = '\u672a\u547d\u540d';
 
 export const canonicalizePath = (path: string): string => {
   const normalized = path.replace(/\//g, '\\');
+  const isUnc = normalized.startsWith('\\\\');
+  if (isUnc) {
+    return `\\\\${normalizeParts(normalized.slice(2).split('\\'), 2).join('\\')}`;
+  }
+
   const driveMatch = normalized.match(/^([a-zA-Z]:)(.*)$/);
   const prefix = driveMatch ? driveMatch[1].toLowerCase() : '';
   const rest = driveMatch ? driveMatch[2] : normalized;
   const absolute = rest.startsWith('\\');
-  const parts: string[] = [];
-
-  rest.split('\\').forEach((part) => {
-    if (!part || part === '.') return;
-    if (part === '..') {
-      parts.pop();
-      return;
-    }
-    parts.push(part.toLowerCase());
-  });
+  const parts = normalizeParts(rest.split('\\'), 0);
 
   const separator = prefix || absolute ? '\\' : '';
   return `${prefix}${separator}${parts.join('\\')}`;
@@ -181,7 +177,34 @@ export const closeTab = (
 const getFileName = (path: string): string => path.split('\\').pop() ?? path;
 
 const getBasePath = (path: string): string | null => {
+  if (path.startsWith('\\\\')) {
+    const parts = path.slice(2).split('\\');
+    parts.pop();
+    return parts.length >= 2 ? `\\\\${parts.join('\\')}` : null;
+  }
+
+  if (/^[a-z]:\\[^\\]+$/i.test(path)) {
+    return `${path.slice(0, 2)}\\`;
+  }
+
   const parts = path.split('\\');
   parts.pop();
   return parts.length > 0 ? parts.join('\\') : null;
+};
+
+const normalizeParts = (parts: string[], rootLength: number): string[] => {
+  const normalized: string[] = [];
+
+  parts.forEach((part) => {
+    if (!part || part === '.') return;
+    if (part === '..') {
+      if (normalized.length > rootLength) {
+        normalized.pop();
+      }
+      return;
+    }
+    normalized.push(part.toLowerCase());
+  });
+
+  return normalized;
 };

--- a/Dev/Typedown.Editor/src/components/Tabs/tabModel.ts
+++ b/Dev/Typedown.Editor/src/components/Tabs/tabModel.ts
@@ -1,0 +1,187 @@
+export type CloseDecision = 'save' | 'dont-save' | 'cancel';
+
+export interface TabDocument {
+  id: string;
+  path: string | null;
+  displayName: string;
+  text: string;
+  cursor: unknown;
+  basePath: string | null;
+  dirty: boolean;
+}
+
+export interface TabState {
+  tabs: TabDocument[];
+  activeTabId: string | null;
+}
+
+interface OpenDocumentArgs {
+  path: string;
+  text: string;
+  cursor?: unknown;
+  basePath?: string | null;
+}
+
+interface SaveResult {
+  success: boolean;
+  path?: string;
+}
+
+interface CloseResult {
+  decision: CloseDecision;
+  nextState: TabState;
+  shouldCloseWindow: boolean;
+}
+
+const UNTITLED_NAME = '\u672a\u547d\u540d';
+
+export const canonicalizePath = (path: string): string => {
+  const normalized = path.replace(/\//g, '\\');
+  const driveMatch = normalized.match(/^([a-zA-Z]:)(.*)$/);
+  const prefix = driveMatch ? driveMatch[1].toLowerCase() : '';
+  const rest = driveMatch ? driveMatch[2] : normalized;
+  const absolute = rest.startsWith('\\');
+  const parts: string[] = [];
+
+  rest.split('\\').forEach((part) => {
+    if (!part || part === '.') return;
+    if (part === '..') {
+      parts.pop();
+      return;
+    }
+    parts.push(part.toLowerCase());
+  });
+
+  const separator = prefix || absolute ? '\\' : '';
+  return `${prefix}${separator}${parts.join('\\')}`;
+};
+
+export const createUntitledTab = (): TabDocument => ({
+  id: `tab-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  path: null,
+  displayName: UNTITLED_NAME,
+  text: '',
+  cursor: null,
+  basePath: null,
+  dirty: false,
+});
+
+export const openDocument = (state: TabState, document: OpenDocumentArgs): TabState => {
+  const path = canonicalizePath(document.path);
+  const existing = state.tabs.find((tab) => tab.path === path);
+
+  if (existing) {
+    return { ...state, activeTabId: existing.id };
+  }
+
+  const tab: TabDocument = {
+    id: `tab-${path}`,
+    path,
+    displayName: getFileName(path),
+    text: document.text,
+    cursor: document.cursor ?? null,
+    basePath: document.basePath ? canonicalizePath(document.basePath) : null,
+    dirty: false,
+  };
+
+  return {
+    tabs: [...state.tabs, tab],
+    activeTabId: tab.id,
+  };
+};
+
+export const updateTabText = (state: TabState, tabId: string, text: string): TabState => ({
+  ...state,
+  tabs: state.tabs.map((tab) => (
+    tab.id === tabId ? { ...tab, text, dirty: true } : tab
+  )),
+});
+
+export const switchTab = (state: TabState, tabId: string): TabState => (
+  state.tabs.some((tab) => tab.id === tabId) ? { ...state, activeTabId: tabId } : state
+);
+
+export const reorderTabs = (state: TabState, fromIndex: number, toIndex: number): TabState => {
+  if (
+    fromIndex < 0
+    || toIndex < 0
+    || fromIndex >= state.tabs.length
+    || toIndex >= state.tabs.length
+    || fromIndex === toIndex
+  ) {
+    return state;
+  }
+
+  const tabs = [...state.tabs];
+  const [moved] = tabs.splice(fromIndex, 1);
+  tabs.splice(toIndex, 0, moved);
+
+  return { ...state, tabs };
+};
+
+export const markTabSaved = (state: TabState, tabId: string, result: SaveResult): TabState => {
+  if (!result.success || !result.path) {
+    return state;
+  }
+
+  const path = canonicalizePath(result.path);
+  const basePath = getBasePath(path);
+
+  return {
+    ...state,
+    tabs: state.tabs.map((tab) => (
+      tab.id === tabId
+        ? {
+          ...tab,
+          path,
+          displayName: getFileName(path),
+          basePath,
+          dirty: false,
+        }
+        : tab
+    )),
+  };
+};
+
+export const closeTab = (
+  state: TabState,
+  tabId: string,
+  decision: CloseDecision,
+  saveResult?: SaveResult,
+): CloseResult => {
+  if (decision === 'cancel') {
+    return { decision, nextState: state, shouldCloseWindow: false };
+  }
+
+  if (decision === 'save' && (!saveResult || !saveResult.success)) {
+    return { decision: 'cancel', nextState: state, shouldCloseWindow: false };
+  }
+
+  const tabIndex = state.tabs.findIndex((tab) => tab.id === tabId);
+  if (tabIndex < 0) {
+    return { decision: 'cancel', nextState: state, shouldCloseWindow: false };
+  }
+
+  const tabs = state.tabs.filter((tab) => tab.id !== tabId);
+  const nextActiveTab = state.activeTabId === tabId
+    ? tabs[Math.min(tabIndex, tabs.length - 1)]
+    : state.tabs.find((tab) => tab.id === state.activeTabId);
+  const nextState = {
+    tabs,
+    activeTabId: nextActiveTab?.id ?? null,
+  };
+
+  return {
+    decision,
+    nextState,
+    shouldCloseWindow: tabs.length === 0,
+  };
+};
+
+const getFileName = (path: string): string => path.split('\\').pop() ?? path;
+
+const getBasePath = (path: string): string | null => {
+  const parts = path.split('\\');
+  parts.pop();
+  return parts.length > 0 ? parts.join('\\') : null;
+};

--- a/Dev/Typedown.Editor/src/services/remote/common.ts
+++ b/Dev/Typedown.Editor/src/services/remote/common.ts
@@ -1,5 +1,43 @@
 import { remoteFunction } from '../transport'
 
+export interface ActivateTabPayload {
+    path: string | null;
+    text: string;
+    dirty: boolean;
+}
+
+export interface SaveTabPayload {
+    path: string | null;
+    text: string;
+    saveAs: boolean;
+}
+
+export interface SaveTabSuccessResult {
+    path: string;
+    basePath: string;
+}
+
+export const buildActivateTabPayload = (path: string | null, text: string, dirty: boolean): ActivateTabPayload => ({
+    path,
+    text,
+    dirty,
+});
+
+export const buildSaveTabPayload = (path: string | null, text: string, saveAs: boolean): SaveTabPayload => ({
+    path,
+    text,
+    saveAs,
+});
+
+export const isConfirmedSaveResult = (result: unknown): result is SaveTabSuccessResult => {
+    if (typeof result !== 'object' || result === null) {
+        return false;
+    }
+
+    const { path, basePath } = result as Partial<SaveTabSuccessResult>;
+    return typeof path === 'string' && path.length > 0 && typeof basePath === 'string' && basePath.length > 0;
+}
+
 const remote = {
     getCurrentTheme: remoteFunction<undefined, string>('GetCurrentTheme'),
     contentLoaded: remoteFunction<undefined, string>('ContentLoaded'),
@@ -10,6 +48,9 @@ const remote = {
     getSettings: remoteFunction<undefined, unknown>('GetSettings'),
     setClipboard: remoteFunction<{ type: string, data: unknown }, boolean>('SetClipboard'),
     getStringResources: remoteFunction<{ names: string[] }, { [name: string]: string }>('GetStringResources'),
+    activateTab: remoteFunction<ActivateTabPayload, undefined>('ActivateTab'),
+    saveTab: remoteFunction<SaveTabPayload, SaveTabSuccessResult | null>('SaveTab'),
+    closeWindow: remoteFunction<undefined, undefined>('CloseWindow'),
     openNewWindow: remoteFunction<string, undefined>('OpenNewWindow'),
     unhandledException: remoteFunction<string, undefined>('UnhandledException'),
 }

--- a/docs/superpowers/plans/2026-07-24-multi-tab.md
+++ b/docs/superpowers/plans/2026-07-24-multi-tab.md
@@ -106,14 +106,9 @@
 
 - [ ] **Step 5: Route existing New/Open/Save menu and shortcut commands into React events.**
 
-  In `FileViewModel`:
+  Do not switch these existing commands to the new event producers in this task: the React receivers are added in Task 3, and switching a producer before its consumer exists would make New/Open/Save no-ops. Keep the current `NewFileCommand`, `OpenFileCommand`, `SaveCommand`, and `SaveAsCommand` subscriptions and behavior unchanged for this task. Task 3 will switch them atomically with the React coordinator and will use `DocumentLoaded` with `{ path, text, basePath, dirty }` so backup recovery is not misreported as clean.
 
-  - `NewFileCommand` posts `NewTabRequested` and must not prompt or overwrite the current document.
-  - `OpenFileCommand` keeps the existing picker/recent-file/read-error behavior but posts `DocumentLoaded` with `{ path, text, basePath }` instead of replacing the React document. It must not call the old single-document `AskToSave` gate before the React tab coordinator receives the document.
-  - `SaveCommand` and `SaveAsCommand` post `SaveRequested` with `{ saveAs: false }` or `{ saveAs: true }`; React performs the active-tab save through `SaveTab`.
-  - Startup loading remains host-owned: `GetSettings` returns the initial document and its `filePath`; it must not emit a second startup tab.
-
-  Preserve folder opening, recent-file recording, backup recovery, export, print, and new-window behavior unless a direct call is required to carry the new document payload.
+  Startup loading remains host-owned: `GetSettings` returns the initial document and its `filePath`; it must not emit a second startup tab. Preserve folder opening, recent-file recording, backup recovery, export, print, and new-window behavior.
 
 - [ ] **Step 6: Build the C# solution and frontend type-check/build.**
 
@@ -142,6 +137,7 @@
 - Create `Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.tsx`
 - Modify `Dev/Typedown.Editor/src/components/Editor/index.tsx`
 - Modify `Dev/Typedown.Editor/src/App.tsx`
+- Modify `Dev/Typedown.Core/ViewModels/FileViewModel.cs`
 
 - [ ] **Step 1: Write failing coordinator tests.**
 
@@ -164,7 +160,7 @@
 
 - [ ] **Step 3: Implement `TabCoordinator`.**
 
-  It owns `TabState`, subscribes to `DocumentLoaded`, `NewTabRequested`, `SaveRequested`, and `LoadFile` only through the existing transport, and exposes the active document to `Editor`. On each editor text/cursor change it updates the model before posting the existing `MarkdownChange`/`CursorChange` messages. On switch it sends `activateTab` with the current snapshot, then sends the existing `LoadFile` message containing the target `{ text, basePath }`; do not mount a second editor.
+  First switch the existing C# `NewFileCommand`, `OpenFileCommand`, `SaveCommand`, and `SaveAsCommand` producers in `FileViewModel.cs` to the new events, in the same change that adds their React receivers. `OpenFileCommand` must emit `DocumentLoaded` as `{ path, text, basePath, dirty }`, preserving a dirty flag when backup recovery supplied the text. The coordinator owns `TabState`, subscribes to `DocumentLoaded`, `NewTabRequested`, and `SaveRequested` through the existing transport, and exposes the active document to `Editor`. On each editor text/cursor change it updates the model before posting the existing `MarkdownChange`/`CursorChange` messages. On switch it sends `activateTab` with the current snapshot, then sends the existing `LoadFile` message containing the target `{ text, basePath }`; do not mount a second editor.
 
   Use one stable ID per tab. Opening a path uses `canonicalizePath`; opening the same file never creates a duplicate. Keep the full canonical path for the tooltip and use `Path.GetFileName`-equivalent behavior on the React side for the visible label.
 

--- a/docs/superpowers/plans/2026-07-24-multi-tab.md
+++ b/docs/superpowers/plans/2026-07-24-multi-tab.md
@@ -71,6 +71,7 @@
 
 **Files:**
 
+- Modify `Dev/Typedown.Editor/src/components/Tabs/tabModel.test.ts`
 - Modify `Dev/Typedown.Editor/src/services/remote/common.ts`
 - Modify `Dev/Typedown.Core/ViewModels/EditorViewModel.cs`
 - Modify `Dev/Typedown.Core/ViewModels/FileViewModel.cs`
@@ -130,7 +131,7 @@
 - [ ] **Step 7: Commit the task.**
 
   ```powershell
-  git add Dev/Typedown.Editor/src/services/remote/common.ts Dev/Typedown.Core/ViewModels/EditorViewModel.cs Dev/Typedown.Core/ViewModels/FileViewModel.cs
+  git add Dev/Typedown.Editor/src/components/Tabs/tabModel.test.ts Dev/Typedown.Editor/src/services/remote/common.ts Dev/Typedown.Core/ViewModels/EditorViewModel.cs Dev/Typedown.Core/ViewModels/FileViewModel.cs
   git commit -m "feat: add tab-aware file operation messages"
   ```
 

--- a/docs/superpowers/plans/2026-07-24-multi-tab.md
+++ b/docs/superpowers/plans/2026-07-24-multi-tab.md
@@ -185,7 +185,7 @@
 - [ ] **Step 7: Commit the task.**
 
   ```powershell
-  git add Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.tsx Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.test.tsx Dev/Typedown.Editor/src/components/Editor/index.tsx Dev/Typedown.Editor/src/App.tsx
+  git add Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.tsx Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.test.tsx Dev/Typedown.Editor/src/components/Editor/index.tsx Dev/Typedown.Editor/src/App.tsx Dev/Typedown.Core/ViewModels/FileViewModel.cs
   git commit -m "feat: coordinate documents across one editor"
   ```
 

--- a/docs/superpowers/plans/2026-07-24-multi-tab.md
+++ b/docs/superpowers/plans/2026-07-24-multi-tab.md
@@ -1,0 +1,304 @@
+# Multi-Tab Document Editor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在官方 Typedown `main` 基线上增加单编辑器、多文档标签页，并保持现有 C# 文件对话框、文件读写、最近文件、保存错误提示和窗口生命周期能力。
+
+**Architecture:** React 维护标签页集合和活动文档快照；现有单个 `Editor` 实例继续负责编辑。C# 保留文件选择器和文件系统操作，通过现有 WebView transport 发送 `DocumentLoaded`、`NewTabRequested`、`SaveRequested`；React 通过现有 `RemoteInvoke` 调用 `ActivateTab`、`SaveTab`、`CloseWindow`。每次切换前先保存当前 React 快照，再激活 C# 当前文档状态，最后把目标文档加载进同一个编辑器。
+
+**Tech Stack:** React 17, TypeScript 4.5, Jest/Testing Library, existing WebView2 message transport, C# WinUI project.
+
+## Global Constraints
+
+- 只修改 `E:\self\playground\typedown-original`，不得修改 `E:\self\repo`。
+- 从干净官方 `main` `a1baeae` 继续，不合并旧的 `feature/multi-tab` 实现。
+- 不新增依赖；优先使用现有 React、TypeScript、Jest 和 WinUI 控件。
+- 保持现有代码风格；每个任务只修改该任务需要的文件。
+- 每个任务先写失败测试，再写最小实现；测试通过后单独提交。
+- 不做重启恢复、多个 WebView、跨窗口同步或新的持久化机制。
+- Windows 路径比较使用规范化后的完整路径并忽略大小写；两个未命名文档可以同时存在。
+- 失败保存、取消关闭和读文件失败都不能丢失当前标签页内容。
+
+---
+
+## Task 1: 建立可测试的标签页状态模型
+
+**Files:**
+
+- Create `Dev/Typedown.Editor/src/components/Tabs/tabModel.ts`
+- Create `Dev/Typedown.Editor/src/components/Tabs/tabModel.test.ts`
+
+- [ ] **Step 1: Write failing model tests.**
+
+  Cover these exact cases:
+
+  - `createUntitledTab` creates a unique ID, `path: null`, display name `未命名`, and `dirty: false`.
+  - `openDocument` canonicalizes a Windows path and activates the existing tab when the same path differs only by case or redundant segments.
+  - `updateTabText` changes only the selected tab and marks it dirty.
+  - switching keeps each tab's text, cursor, and base path unchanged.
+  - `reorderTabs` moves one tab without changing the active ID or document contents.
+  - `markTabSaved` changes the path/name/base path and clears dirty state only after a successful save result.
+  - close decisions return the expected state for `save`, `dont-save`, and `cancel`; closing the last tab reports `shouldCloseWindow: true`.
+
+  Use Jest assertions against the exported model functions; do not render React components in this task.
+
+- [ ] **Step 2: Run the focused test and confirm it fails for the expected missing-module reason.**
+
+  Command from `Dev/Typedown.Editor`:
+
+  ```powershell
+  yarn test --watchAll=false --runTestsByPath src/components/Tabs/tabModel.test.ts
+  ```
+
+  Expected result: Jest cannot resolve the new `tabModel` module or the exported functions do not yet exist.
+
+- [ ] **Step 3: Implement the smallest model.**
+
+  Export `TabDocument`, `TabState`, `CloseDecision`, `canonicalizePath`, `createUntitledTab`, `openDocument`, `updateTabText`, `switchTab`, `reorderTabs`, `markTabSaved`, and `closeTab`. Keep the model pure: no transport, React state, dialogs, filesystem calls, or generated global state.
+
+- [ ] **Step 4: Re-run the focused test.**
+
+  Expected result: all model tests pass.
+
+- [ ] **Step 5: Commit the task.**
+
+  ```powershell
+  git add Dev/Typedown.Editor/src/components/Tabs/tabModel.ts Dev/Typedown.Editor/src/components/Tabs/tabModel.test.ts
+  git commit -m "test: add multi-tab state model"
+  ```
+
+## Task 2: Define the WebView file-operation contract
+
+**Files:**
+
+- Modify `Dev/Typedown.Editor/src/services/remote/common.ts`
+- Modify `Dev/Typedown.Core/ViewModels/EditorViewModel.cs`
+- Modify `Dev/Typedown.Core/ViewModels/FileViewModel.cs`
+
+- [ ] **Step 1: Add contract-level tests or test fixtures before changing behavior.**
+
+  Extend `tabModel.test.ts` with the React-side payload builders or type guards used for:
+
+  - `ActivateTab`: `{ path: string | null, text: string, dirty: boolean }`.
+  - `SaveTab`: `{ path: string | null, text: string, saveAs: boolean }`.
+  - successful save result: `{ path: string, basePath: string }`.
+
+  The test must reject a save result without a confirmed path; React must not clear dirty state from an unconfirmed result.
+
+- [ ] **Step 2: Add typed remote functions in `common.ts`.**
+
+  Add `activateTab`, `saveTab`, and `closeWindow` using the existing `remoteFunction` helper. Do not add a new transport implementation. The names must be exactly `ActivateTab`, `SaveTab`, and `CloseWindow`.
+
+- [ ] **Step 3: Extend startup settings with file identity.**
+
+  In `EditorViewModel.GetSettings`, include `filePath: FileViewModel.FilePath` alongside the existing `markdown` and `basePath`. Keep the existing settings shape unchanged otherwise.
+
+- [ ] **Step 4: Add the C# handlers in `FileViewModel`.**
+
+  Register handlers through the existing `RemoteInvoke` instance:
+
+  - `ActivateTab` updates `FilePath`, `EditorViewModel.Markdown`, `CurrentHash`, `FileHash`, and `Saved` from the payload. For a dirty payload, make the host recognize the active text as unsaved so existing autosave/export operations still operate on the active tab.
+  - `SaveTab` writes the supplied text. With `saveAs: false` and a non-null path, write to that path; with `saveAs: true` or a null path, use the existing `FileSavePicker`. Return the actual saved path and `ImageBasePath` only after the write succeeds. Reuse the existing save-error dialog path; a failed write returns an unsuccessful result and leaves the tab dirty.
+  - `CloseWindow` invokes the existing window-close path only after React has resolved the last-tab decision.
+
+  Keep the current `Save` and `SaveAs` helpers available for existing host lifecycle code; extract only the shared write/picker logic needed by `SaveTab` rather than rewriting unrelated file behavior.
+
+- [ ] **Step 5: Route existing New/Open/Save menu and shortcut commands into React events.**
+
+  In `FileViewModel`:
+
+  - `NewFileCommand` posts `NewTabRequested` and must not prompt or overwrite the current document.
+  - `OpenFileCommand` keeps the existing picker/recent-file/read-error behavior but posts `DocumentLoaded` with `{ path, text, basePath }` instead of replacing the React document. It must not call the old single-document `AskToSave` gate before the React tab coordinator receives the document.
+  - `SaveCommand` and `SaveAsCommand` post `SaveRequested` with `{ saveAs: false }` or `{ saveAs: true }`; React performs the active-tab save through `SaveTab`.
+  - Startup loading remains host-owned: `GetSettings` returns the initial document and its `filePath`; it must not emit a second startup tab.
+
+  Preserve folder opening, recent-file recording, backup recovery, export, print, and new-window behavior unless a direct call is required to carry the new document payload.
+
+- [ ] **Step 6: Build the C# solution and frontend type-check/build.**
+
+  Commands:
+
+  ```powershell
+  cd E:\self\playground\typedown-original\Dev\Typedown.Editor
+  yarn build
+  cd E:\self\playground\typedown-original
+  dotnet build Typedown.sln --no-restore
+  ```
+
+  Expected result: both commands complete successfully. If the environment lacks the required Windows/.NET workload, record the exact blocker and continue with frontend verification; do not silently claim the C# side is verified.
+
+- [ ] **Step 7: Commit the task.**
+
+  ```powershell
+  git add Dev/Typedown.Editor/src/services/remote/common.ts Dev/Typedown.Core/ViewModels/EditorViewModel.cs Dev/Typedown.Core/ViewModels/FileViewModel.cs
+  git commit -m "feat: add tab-aware file operation messages"
+  ```
+
+## Task 3: Integrate the single editor with the tab coordinator
+
+**Files:**
+
+- Create `Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.tsx`
+- Modify `Dev/Typedown.Editor/src/components/Editor/index.tsx`
+- Modify `Dev/Typedown.Editor/src/App.tsx`
+
+- [ ] **Step 1: Write failing coordinator tests.**
+
+  Create `Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.test.tsx` using mocked `remote` and `transport`. Cover:
+
+  - startup settings creates exactly one tab using `filePath`, `markdown`, and `basePath`;
+  - `DocumentLoaded` opens a new tab or activates the existing canonical path;
+  - editor changes update only the active tab;
+  - switching calls `activateTab` before loading the target document into the editor;
+  - a failed `saveTab` call leaves the tab dirty and active;
+  - `NewTabRequested` creates an untitled tab without replacing existing tabs;
+  - `CloseWindow` is called only after the last tab is closed without pending dirty work.
+
+- [ ] **Step 2: Run the focused coordinator test and confirm the expected failure.**
+
+  ```powershell
+  cd E:\self\playground\typedown-original\Dev\Typedown.Editor
+  yarn test --watchAll=false --runTestsByPath src/components/Tabs/TabCoordinator.test.tsx
+  ```
+
+- [ ] **Step 3: Implement `TabCoordinator`.**
+
+  It owns `TabState`, subscribes to `DocumentLoaded`, `NewTabRequested`, `SaveRequested`, and `LoadFile` only through the existing transport, and exposes the active document to `Editor`. On each editor text/cursor change it updates the model before posting the existing `MarkdownChange`/`CursorChange` messages. On switch it sends `activateTab` with the current snapshot, then sends the existing `LoadFile` message containing the target `{ text, basePath }`; do not mount a second editor.
+
+  Use one stable ID per tab. Opening a path uses `canonicalizePath`; opening the same file never creates a duplicate. Keep the full canonical path for the tooltip and use `Path.GetFileName`-equivalent behavior on the React side for the visible label.
+
+- [ ] **Step 4: Make `Editor` controlled by coordinator callbacks without changing editor engines.**
+
+  Add props for `onMarkdownChange` and `onCursorChange`, and invoke them wherever the existing editor state changes. Keep Muya/CodeMirror selection, search, export, import, and settings behavior intact. Retain the existing `LoadFile` listener and make it update the single editor instance from the coordinator.
+
+- [ ] **Step 5: Mount the coordinator once from `App.tsx`.**
+
+  Keep the existing `ErrorBoundary`. The resulting component tree must contain one `Editor` and one tab coordinator; no per-tab Muya or CodeMirror instances.
+
+- [ ] **Step 6: Run the focused tests and frontend build.**
+
+  ```powershell
+  cd E:\self\playground\typedown-original\Dev\Typedown.Editor
+  yarn test --watchAll=false --runTestsByPath src/components/Tabs/tabModel.test.ts src/components/Tabs/TabCoordinator.test.tsx
+  yarn build
+  ```
+
+  Expected result: focused tests pass and the production frontend build completes.
+
+- [ ] **Step 7: Commit the task.**
+
+  ```powershell
+  git add Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.tsx Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.test.tsx Dev/Typedown.Editor/src/components/Editor/index.tsx Dev/Typedown.Editor/src/App.tsx
+  git commit -m "feat: coordinate documents across one editor"
+  ```
+
+## Task 4: Add the tab bar and dirty-close interaction
+
+**Files:**
+
+- Create `Dev/Typedown.Editor/src/components/Tabs/TabBar.tsx`
+- Create `Dev/Typedown.Editor/src/components/Tabs/TabBar.scss`
+- Create `Dev/Typedown.Editor/src/components/Tabs/DirtyCloseDialog.tsx`
+- Create `Dev/Typedown.Editor/src/components/Tabs/DirtyCloseDialog.scss`
+- Modify `Dev/Typedown.Editor/src/components/Tabs/TabCoordinator.tsx`
+- Modify `Dev/Typedown.Editor/src/App.scss`
+
+- [ ] **Step 1: Write failing UI tests.**
+
+  Add `Dev/Typedown.Editor/src/components/Tabs/TabBar.test.tsx` with Testing Library coverage for:
+
+  - filename is visible and full path is exposed through the tab tooltip;
+  - `未命名` is shown for an untitled document;
+  - clicking a tab selects it;
+  - dragging a tab requests reorder;
+  - clicking `+` requests a new untitled tab;
+  - dirty close shows exactly `Save`, `Don't Save`, and `Cancel`;
+  - `Cancel` leaves the tab and active document unchanged;
+  - closing the last clean tab invokes `CloseWindow`.
+
+- [ ] **Step 2: Run the focused UI test and confirm the expected failure.**
+
+  ```powershell
+  cd E:\self\playground\typedown-original\Dev\Typedown.Editor
+  yarn test --watchAll=false --runTestsByPath src/components/Tabs/TabBar.test.tsx
+  ```
+
+- [ ] **Step 3: Implement `TabBar` and the dialog.**
+
+  Keep controls keyboard-accessible with buttons and labels. Render the tab filename, dirty marker, close button, and `+`. Use the full path as the native `title` tooltip. Use native HTML5 drag events for reorder so no dependency is needed. The dialog must return one of the three explicit decisions and must not close the tab before the decision is applied.
+
+- [ ] **Step 4: Connect tab-bar actions in `TabCoordinator`.**
+
+  For a dirty close, `Save` awaits `saveTab`; only a successful result permits removal. `Don't Save` removes the tab without calling `saveTab`. `Cancel` does nothing. After a successful Save As, update the tab path, visible name, tooltip path, and base path from the returned actual path.
+
+- [ ] **Step 5: Add layout/styles without changing editor-engine styles.**
+
+  Place the tab bar above the existing editor content. Match current app colors and focus states. Keep the tab bar usable in source-code mode and focus mode unless the current layout intentionally hides chrome; do not add persistence or a second scrollable editor.
+
+- [ ] **Step 6: Run all frontend tests and build.**
+
+  ```powershell
+  cd E:\self\playground\typedown-original\Dev\Typedown.Editor
+  yarn test --watchAll=false
+  yarn build
+  ```
+
+  Expected result: all frontend tests pass and the build completes.
+
+- [ ] **Step 7: Commit the task.**
+
+  ```powershell
+  git add Dev/Typedown.Editor/src/components/Tabs Dev/Typedown.Editor/src/App.scss
+  git commit -m "feat: add multi-tab editor UI"
+  ```
+
+## Task 5: Verify Windows integration and regression behavior
+
+**Files:**
+
+- Modify only files required by observed integration failures; do not perform unrelated cleanup.
+- If a C# test is added, place it under `Tests/Typedown.Test` and keep it limited to a pure helper extracted from `FileViewModel`.
+
+- [ ] **Step 1: Run the complete automated verification.**
+
+  ```powershell
+  cd E:\self\playground\typedown-original\Dev\Typedown.Editor
+  yarn test --watchAll=false
+  yarn build
+  cd E:\self\playground\typedown-original
+  dotnet build Typedown.sln --no-restore
+  ```
+
+- [ ] **Step 2: Run the real Windows manual matrix in Debug_Local.**
+
+  Verify, from a clean launch:
+
+  1. startup with no file creates one `未命名` tab;
+  2. `+`, File > New, and Ctrl+N each create an additional untitled tab;
+  3. open two different Markdown files and switch between them without text loss;
+  4. opening an already-open file selects its existing tab;
+  5. filename and full-path tooltip are correct, including paths containing spaces and mixed case;
+  6. drag reorder changes only tab order;
+  7. edit a tab, close it, and verify Save/Don't Save/Cancel behavior;
+  8. Save As updates the label and tooltip only after the picker/write succeeds;
+  9. close the last tab and verify the Typedown window closes;
+  10. verify existing export, print, import, recent files, image-relative paths, Ctrl+S, Ctrl+Shift+S, and Ctrl+O still operate on the active tab.
+
+- [ ] **Step 3: If a failure appears, use `superpowers:systematic-debugging` before editing.**
+
+  Record the reproduction, failing boundary (React model, transport, C# file operation, or window lifecycle), and the smallest regression test before making the fix.
+
+- [ ] **Step 4: Re-run the affected focused test, then the complete verification.**
+
+- [ ] **Step 5: Commit only the verified fix.**
+
+  Use a focused message such as `fix: preserve active tab during save failure`; do not bundle unrelated formatting changes.
+
+## Completion and GitHub handoff
+
+- [ ] Run `git status --short`, confirm only intended files are changed, and inspect `git diff --check`.
+- [ ] Run `git log --oneline --decorate -n 8` and explain each task commit to the user.
+- [ ] Push the feature branch to the user's fork as `origin` after confirming the branch name and commit scope.
+- [ ] Open a Draft Pull Request from `sharply-x/Typedown:<branch>` to `byxiaozhi/Typedown:main`, with the design document, tests run, manual verification status, and known environment limitations.
+- [ ] Use `superpowers:requesting-code-review` before the PR is considered ready, and use `superpowers:finishing-a-development-branch` only after review findings are resolved.
+

--- a/docs/superpowers/specs/2026-07-24-multi-tab-document-editor-design.md
+++ b/docs/superpowers/specs/2026-07-24-multi-tab-document-editor-design.md
@@ -1,0 +1,109 @@
+# Multi-Tab Document Editor Design
+
+**Date:** 2026-07-24
+
+**Project baseline:** Official `byxiaozhi/Typedown` `main` at `a1baeae`.
+
+## Goal
+
+Add a first-version document-tab experience to Typedown while preserving its existing Windows file operations and editor behavior.
+
+## Confirmed user behavior
+
+- Each tab represents one document.
+- A tab displays the file name.
+- Hovering a tab displays the full file path.
+- An untitled document is labeled `未命名` and has no file path.
+- The tab `+` button, the existing New File menu command, and its shortcut all create a new untitled document.
+- Opening a file that is already open activates its existing tab instead of creating a duplicate.
+- Tabs can be switched and reordered by dragging.
+- Closing a dirty tab presents `Save`, `Don't Save`, and `Cancel`.
+- Closing the last tab closes the Typedown window.
+- Restart recovery is out of scope for this version.
+
+## Scope
+
+### In scope
+
+- Tab bar UI and styles consistent with the existing editor.
+- Tab state for file path, display name, Markdown text, dirty state, and the active tab.
+- Opening files from existing C# commands into tabs.
+- New untitled documents from all confirmed entry points.
+- Switching and reordering tabs without losing document text.
+- Save, Save As, discard, and cancel behavior for the active tab.
+- Updating the tab name and path after Save As.
+- Closing the host window after the last tab is closed.
+
+### Out of scope
+
+- Restoring tabs after application restart.
+- Multiple native WebView/editor instances.
+- Cross-window tab synchronization.
+- New persistence, synchronization, or third-party dependencies.
+
+## Architecture
+
+Use one existing editor instance and add a React-side tab coordinator.
+
+React owns the in-window tab collection and the active document snapshot. Each tab contains:
+
+- a stable tab ID;
+- a nullable canonical file path;
+- a display file name;
+- Markdown text;
+- dirty state;
+- cursor state needed to restore the editing position.
+
+The existing C# layer remains responsible for file dialogs, filesystem reads and writes, recent-file history, save errors, and window lifetime. It sends file-loading and save-result messages through the existing WebView transport. React sends the active tab's content and path when a save operation needs to be performed.
+
+The editor component remains mounted once. Switching tabs first snapshots the current editor state into the active tab, then loads the target tab's text, image base path, and cursor. This avoids multiple editor instances and keeps the implementation compatible with the current React 17 and WebView communication model.
+
+On Windows, file identity comparison is case-insensitive and uses canonical full paths. Two untitled documents are allowed because they have no path identity.
+
+## Message/data flow
+
+1. Startup or an existing Open command causes C# to provide the loaded document's canonical path, text, and image base path.
+2. React creates or activates the corresponding tab and loads the text into the single editor.
+3. Editor changes update the active tab snapshot and mark it dirty.
+4. Switching tabs snapshots the current tab, then loads the selected tab snapshot into the editor.
+5. Save or Save As sends the active tab identity and content to C#. C# returns the actual saved path and success/error information.
+6. On success, React marks the tab clean and updates its display name and tooltip path.
+7. Closing a dirty tab waits for the user's Save, Don't Save, or Cancel choice. Closing the last tab sends a close-window message to C#.
+
+All new messages must be narrowly scoped, documented at their call sites, and use the existing transport rather than introducing a second IPC mechanism.
+
+## Error handling
+
+- A failed save keeps the tab open and dirty and surfaces the existing host error dialog.
+- Cancel leaves the tab collection, active tab, and editor content unchanged.
+- A missing or unreadable file does not silently replace the active tab; the host reports the error and the current tab remains available.
+- A stale file path after Save As is replaced only after C# confirms the successful save path.
+
+## Verification strategy
+
+Write focused tests before implementation for the tab-state behavior:
+
+- creating a new untitled tab;
+- opening and deduplicating a canonical file path;
+- switching tabs while preserving each document's text;
+- reordering tabs;
+- dirty close decisions for Save, Don't Save, and Cancel;
+- closing the last tab and emitting the window-close message;
+- updating the display name and tooltip path after Save As.
+
+Run the focused frontend tests first, then the frontend build, then the relevant C# tests that are available in the environment. Manual verification must cover the real Windows host because WebView messages and file dialogs are not fully represented by frontend unit tests.
+
+## Collaboration and GitHub workflow
+
+The implementation follows Superpowers' sequence: design approval, isolated branch, written plan, small implementation tasks, test-first changes, task review after each task, and final review before integration.
+
+The GitHub teaching workflow uses the official Typedown repository as `upstream` and the user's fork as `origin`. The local branch will be created from the clean upstream `main`; no changes from the previous local `feature/multi-tab` branch are used. The work will be pushed to the fork and opened as a Draft Pull Request against the upstream repository.
+
+Each implementation task should have a focused commit, a test result, and a review checkpoint. The modifying agent writes code and tests; the review agent checks the requirements and diff, then sends actionable findings back to the modifying agent for correction and re-review.
+
+## Constraints
+
+- Preserve existing project style and file organization.
+- Do not add dependencies unless the current code cannot support the behavior without one.
+- Keep the first version limited to the confirmed behavior above.
+- Do not modify or reset the unrelated repository at `E:\self\repo`.


### PR DESCRIPTION
- **docs: define multi-tab design**
- **docs: add multi-tab implementation plan**
- **chore: ignore local worktrees**
- **test: add multi-tab state model**
- **fix: preserve tab path roots**
- **docs: include task test file in plan**
- **feat: add tab-aware file operation messages**
- **docs: sequence tab message producers with consumers**
- **fix: restore host file command flow**
- **docs: include host producer in task 3**
- **feat: coordinate documents across one editor**
- **fix: keep tab switches from replaying editor edits**
- **feat: add multi-tab editor UI**
