### PR TITLE
Add Arabic/RTL text direction support and editor font family setting

### DIFF
--- a/Dev/Typedown.Core/Controls/SettingControls/SettingItems/EditorSetting.xaml
+++ b/Dev/Typedown.Core/Controls/SettingControls/SettingItems/EditorSetting.xaml
@@ -32,6 +32,30 @@
             </controls:NormalSettingItem.Icon>
             <TextBox MinWidth="200" Text="{x:Bind Settings.EditorAreaWidth, Mode=TwoWay}"/>
         </controls:NormalSettingItem>
+        <controls:NormalSettingItem Title="{u:LocaleString Key=Editor.FontFamily.Title}" Description="{u:LocaleString Key=Editor.FontFamily.Description}">
+            <controls:NormalSettingItem.Icon>
+                <FontIcon Glyph="&#xe8d2;"/>
+            </controls:NormalSettingItem.Icon>
+            <AutoSuggestBox MinWidth="200"
+                Text="{x:Bind Settings.FontFamily, Mode=OneWay}"
+                PlaceholderText="{u:LocaleString Key=Editor.FontFamily.Placeholder}"
+                ItemsSource="{x:Bind FontFamilySuggestions}"
+                TextChanged="OnFontFamilyTextChanged"
+                SuggestionChosen="OnFontFamilySuggestionChosen"
+                QuerySubmitted="OnFontFamilyQuerySubmitted"/>
+        </controls:NormalSettingItem>
+        <controls:NormalSettingItem Title="{u:LocaleString Key=Editor.TextDirection.Title}" Description="{u:LocaleString Key=Editor.TextDirection.Description}">
+            <controls:NormalSettingItem.Icon>
+                <FontIcon Glyph="&#xe8ab;"/>
+            </controls:NormalSettingItem.Icon>
+            <ComboBox MinWidth="200" ItemsSource="{x:Bind local:EditorSetting.TextDirectionOptions.Keys}" SelectedItem="{x:Bind Settings.TextDirection, Mode=TwoWay}">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate x:DataType="x:String">
+                        <TextBlock Text="{x:Bind local:EditorSetting.GetTextDirectionDisplayName((x:String))}"/>
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+        </controls:NormalSettingItem>
         <TextBlock Text="Markdown" Margin="0,16,0,4"/>
         <controls:NormalSettingItem Title="{u:LocaleString Key=Editor.TabSize.Title}" Description="{u:LocaleString Key=Editor.TabSize.Description}">
             <controls:NormalSettingItem.Icon>

--- a/Dev/Typedown.Core/Controls/SettingControls/SettingItems/EditorSetting.xaml.cs
+++ b/Dev/Typedown.Core/Controls/SettingControls/SettingItems/EditorSetting.xaml.cs
@@ -1,4 +1,10 @@
-﻿using Typedown.Core.ViewModels;
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Drawing.Text;
+using System.Linq;
+using Typedown.Core.Utilities;
+using Typedown.Core.ViewModels;
 using Windows.Globalization.NumberFormatting;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -17,9 +23,60 @@ namespace Typedown.Core.Controls.SettingControls.SettingItems
 
         public DecimalFormatter IntegerFormatter { get; } = new() { FractionDigits = 0, NumberRounder = new IncrementNumberRounder { Increment = 1, RoundingAlgorithm = RoundingAlgorithm.RoundHalfUp } };
 
+        // Every font family actually installed on this machine (evaluated once, lazily).
+        private static readonly Lazy<List<string>> installedFontFamilies = new(() =>
+        {
+            using var installedFonts = new InstalledFontCollection();
+            return installedFonts.Families
+                .Select(f => f.Name)
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .Distinct()
+                .OrderBy(name => name, StringComparer.CurrentCultureIgnoreCase)
+                .ToList();
+        });
+
+        public ObservableCollection<string> FontFamilySuggestions { get; } = new();
+
+        public static Dictionary<string, string> TextDirectionOptions { get; } = new()
+        {
+            { "auto", Locale.GetString("Editor.TextDirection.Auto") },
+            { "ltr", Locale.GetString("Editor.TextDirection.Ltr") },
+            { "rtl", Locale.GetString("Editor.TextDirection.Rtl") },
+        };
+
+        public static string GetTextDirectionDisplayName(string key) => TextDirectionOptions.TryGetValue(key, out var value) ? value : key;
+
         public EditorSetting()
         {
             InitializeComponent();
+            UpdateFontFamilySuggestions(string.Empty);
+        }
+
+        private void UpdateFontFamilySuggestions(string filter)
+        {
+            var matches = string.IsNullOrEmpty(filter)
+                ? installedFontFamilies.Value
+                : installedFontFamilies.Value.Where(name => name.IndexOf(filter, StringComparison.CurrentCultureIgnoreCase) >= 0);
+            FontFamilySuggestions.Clear();
+            foreach (var name in matches.Take(50))
+                FontFamilySuggestions.Add(name);
+        }
+
+        private void OnFontFamilyTextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+        {
+            if (args.Reason == AutoSuggestionBoxTextChangeReason.UserInput)
+                UpdateFontFamilySuggestions(sender.Text);
+        }
+
+        private void OnFontFamilySuggestionChosen(AutoSuggestBox sender, AutoSuggestBoxSuggestionChosenEventArgs args)
+        {
+            if (args.SelectedItem is string fontFamily)
+                Settings.FontFamily = fontFamily;
+        }
+
+        private void OnFontFamilyQuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
+        {
+            Settings.FontFamily = args.ChosenSuggestion as string ?? args.QueryText;
         }
 
         private void OnUnloaded(object sender, RoutedEventArgs e)

--- a/Dev/Typedown.Core/Resources/Strings/ar/SettingsResources.resw
+++ b/Dev/Typedown.Core/Resources/Strings/ar/SettingsResources.resw
@@ -197,6 +197,18 @@
     <value>الامتدادات</value>
     <comment>编辑器/扩展</comment>
   </data>
+  <data name="Editor.FontFamily.Description" xml:space="preserve">
+    <value>الخط المستخدم في محتوى المحرر. اتركه فارغًا لاستخدام الخط الافتراضي.</value>
+    <comment>编辑器/编辑器内容使用的字体，留空则使用默认字体</comment>
+  </data>
+  <data name="Editor.FontFamily.Placeholder" xml:space="preserve">
+    <value>افتراضي</value>
+    <comment>编辑器/默认</comment>
+  </data>
+  <data name="Editor.FontFamily.Title" xml:space="preserve">
+    <value>الخط</value>
+    <comment>编辑器/字体</comment>
+  </data>
   <data name="Editor.FontSize.Description" xml:space="preserve">
     <value>حجم الخط الافتراضي للمحرر</value>
     <comment>编辑器/编辑器默认字号</comment>
@@ -232,6 +244,26 @@
   <data name="Editor.Style" xml:space="preserve">
     <value>النمط</value>
     <comment>编辑器/样式</comment>
+  </data>
+  <data name="Editor.TextDirection.Auto" xml:space="preserve">
+    <value>اكتشاف تلقائي لكل فقرة</value>
+    <comment>编辑器/按段落自动检测</comment>
+  </data>
+  <data name="Editor.TextDirection.Description" xml:space="preserve">
+    <value>اتجاه النص في محتوى المحرر، مفيد للغة العربية والعبرية وغيرها من اللغات التي تُكتب من اليمين إلى اليسار</value>
+    <comment>编辑器/编辑器内容的文字方向，适用于阿拉伯语、希伯来语等从右到左书写的语言</comment>
+  </data>
+  <data name="Editor.TextDirection.Ltr" xml:space="preserve">
+    <value>من اليسار إلى اليمين</value>
+    <comment>编辑器/从左到右</comment>
+  </data>
+  <data name="Editor.TextDirection.Rtl" xml:space="preserve">
+    <value>من اليمين إلى اليسار</value>
+    <comment>编辑器/从右到左</comment>
+  </data>
+  <data name="Editor.TextDirection.Title" xml:space="preserve">
+    <value>اتجاه النص</value>
+    <comment>编辑器/文字方向</comment>
   </data>
   <data name="Editor.TabSize.Description" xml:space="preserve">
     <value>ضبط المسافة الافتراضية للمقتبسات والقوائم</value>

--- a/Dev/Typedown.Core/Resources/Strings/en/SettingsResources.resw
+++ b/Dev/Typedown.Core/Resources/Strings/en/SettingsResources.resw
@@ -197,6 +197,18 @@
     <value>Extensions</value>
     <comment>编辑器/扩展</comment>
   </data>
+  <data name="Editor.FontFamily.Description" xml:space="preserve">
+    <value>Font used for editor content. Leave empty to use the default font.</value>
+    <comment>编辑器/编辑器内容使用的字体，留空则使用默认字体</comment>
+  </data>
+  <data name="Editor.FontFamily.Placeholder" xml:space="preserve">
+    <value>Default</value>
+    <comment>编辑器/默认</comment>
+  </data>
+  <data name="Editor.FontFamily.Title" xml:space="preserve">
+    <value>Font family</value>
+    <comment>编辑器/字体</comment>
+  </data>
   <data name="Editor.FontSize.Description" xml:space="preserve">
     <value>Default font size of editor.</value>
     <comment>编辑器/编辑器默认字号</comment>
@@ -232,6 +244,26 @@
   <data name="Editor.Style" xml:space="preserve">
     <value>Style</value>
     <comment>编辑器/样式</comment>
+  </data>
+  <data name="Editor.TextDirection.Auto" xml:space="preserve">
+    <value>Auto detect per paragraph</value>
+    <comment>编辑器/按段落自动检测</comment>
+  </data>
+  <data name="Editor.TextDirection.Description" xml:space="preserve">
+    <value>Text direction of editor content, useful for Arabic, Hebrew and other right-to-left languages</value>
+    <comment>编辑器/编辑器内容的文字方向，适用于阿拉伯语、希伯来语等从右到左书写的语言</comment>
+  </data>
+  <data name="Editor.TextDirection.Ltr" xml:space="preserve">
+    <value>Left to right</value>
+    <comment>编辑器/从左到右</comment>
+  </data>
+  <data name="Editor.TextDirection.Rtl" xml:space="preserve">
+    <value>Right to left</value>
+    <comment>编辑器/从右到左</comment>
+  </data>
+  <data name="Editor.TextDirection.Title" xml:space="preserve">
+    <value>Text direction</value>
+    <comment>编辑器/文字方向</comment>
   </data>
   <data name="Editor.TabSize.Description" xml:space="preserve">
     <value>Adjust default indentation space for quotes and lists</value>

--- a/Dev/Typedown.Core/Resources/Strings/zh-Hans/SettingsResources.resw
+++ b/Dev/Typedown.Core/Resources/Strings/zh-Hans/SettingsResources.resw
@@ -197,6 +197,18 @@
     <value>扩展</value>
     <comment>编辑器/扩展</comment>
   </data>
+  <data name="Editor.FontFamily.Description" xml:space="preserve">
+    <value>编辑器内容使用的字体，留空则使用默认字体</value>
+    <comment>编辑器/编辑器内容使用的字体，留空则使用默认字体</comment>
+  </data>
+  <data name="Editor.FontFamily.Placeholder" xml:space="preserve">
+    <value>默认</value>
+    <comment>编辑器/默认</comment>
+  </data>
+  <data name="Editor.FontFamily.Title" xml:space="preserve">
+    <value>字体</value>
+    <comment>编辑器/字体</comment>
+  </data>
   <data name="Editor.FontSize.Description" xml:space="preserve">
     <value>编辑器默认字号</value>
     <comment>编辑器/编辑器默认字号</comment>
@@ -232,6 +244,26 @@
   <data name="Editor.Style" xml:space="preserve">
     <value>样式</value>
     <comment>编辑器/样式</comment>
+  </data>
+  <data name="Editor.TextDirection.Auto" xml:space="preserve">
+    <value>按段落自动检测</value>
+    <comment>编辑器/按段落自动检测</comment>
+  </data>
+  <data name="Editor.TextDirection.Description" xml:space="preserve">
+    <value>编辑器内容的文字方向，适用于阿拉伯语、希伯来语等从右到左书写的语言</value>
+    <comment>编辑器/编辑器内容的文字方向，适用于阿拉伯语、希伯来语等从右到左书写的语言</comment>
+  </data>
+  <data name="Editor.TextDirection.Ltr" xml:space="preserve">
+    <value>从左到右</value>
+    <comment>编辑器/从左到右</comment>
+  </data>
+  <data name="Editor.TextDirection.Rtl" xml:space="preserve">
+    <value>从右到左</value>
+    <comment>编辑器/从右到左</comment>
+  </data>
+  <data name="Editor.TextDirection.Title" xml:space="preserve">
+    <value>文字方向</value>
+    <comment>编辑器/文字方向</comment>
   </data>
   <data name="Editor.TabSize.Description" xml:space="preserve">
     <value>调整引用和列表的默认缩进空格</value>

--- a/Dev/Typedown.Core/Typedown.Core.csproj
+++ b/Dev/Typedown.Core/Typedown.Core.csproj
@@ -458,6 +458,9 @@
     <PackageReference Include="PropertyChanged.Fody">
       <Version>4.1.0</Version>
     </PackageReference>
+    <PackageReference Include="System.Drawing.Common">
+      <Version>4.7.3</Version>
+    </PackageReference>
     <PackageReference Include="System.Reactive">
       <Version>5.0.0</Version>
     </PackageReference>

--- a/Dev/Typedown.Core/ViewModels/EditorViewModel.cs
+++ b/Dev/Typedown.Core/ViewModels/EditorViewModel.cs
@@ -112,6 +112,8 @@ namespace Typedown.Core.ViewModels
                 Settings.PreferLooseListItem,
                 Settings.AutoPairMarkdownSyntax,
                 Settings.EditorAreaWidth,
+                Settings.FontFamily,
+                Settings.TextDirection,
                 Settings.TabSize,
                 Markdown,
                 BasePath = FileViewModel.ImageBasePath,

--- a/Dev/Typedown.Core/ViewModels/SettingsViewModel.cs
+++ b/Dev/Typedown.Core/ViewModels/SettingsViewModel.cs
@@ -38,6 +38,8 @@ namespace Typedown.Core.ViewModels
         public bool PreferLooseListItem { get => GetSettingValue(true); set => SetSettingValue(value); }
         public bool AutoPairMarkdownSyntax { get => GetSettingValue(true); set => SetSettingValue(value); }
         public string EditorAreaWidth { get => GetSettingValue("1200px"); set => SetSettingValue(value); }
+        public string FontFamily { get => GetSettingValue(""); set => SetSettingValue(value); }
+        public string TextDirection { get => GetSettingValue("auto"); set => SetSettingValue(value); }
         public bool AutoSave { get => GetSettingValue(false); set => SetSettingValue(value); }
         public AppTheme AppTheme { get => GetSettingValue(AppTheme.Default); set => SetSettingValue(value); }
         public string Language { get => GetSettingValue("default"); set => SetSettingValue(value); }
@@ -97,7 +99,9 @@ namespace Typedown.Core.ViewModels
             "TrimUnnecessaryCodeBlockEmptyLines",
             "PreferLooseListItem",
             "AutoPairMarkdownSyntax",
-            "EditorAreaWidth"
+            "EditorAreaWidth",
+            "FontFamily",
+            "TextDirection"
         };
 
         public SettingsViewModel(IServiceProvider serviceProvider)

--- a/Dev/Typedown.Editor/src/components/CodeMirror/index.tsx
+++ b/Dev/Typedown.Editor/src/components/CodeMirror/index.tsx
@@ -278,7 +278,8 @@ const CodeMirrorEditor: React.FC<ICodeMirrorEditor> = (props) => {
                 paddingLeft: 14,
                 paddingRight: 14,
                 fontSize: props.options?.fontSize,
-                lineHeight: props.options?.lineHeight
+                lineHeight: props.options?.lineHeight,
+                fontFamily: props.options?.fontFamily ? `${props.options.fontFamily}, "Open Sans", "Segoe UI", sans-serif` : undefined
             }}>
             <CodeMirror
                 ref={(ref: any) => ref && setEditor(ref.editor)}

--- a/Dev/Typedown.Editor/src/components/Muya/index.tsx
+++ b/Dev/Typedown.Editor/src/components/Muya/index.tsx
@@ -143,6 +143,10 @@ const MuyaEditor: React.FC<IMuyaEditor> = (props) => {
         editor?.setFont({ fontSize: props.options?.fontSize, lineHeight: props.options?.lineHeight })
     }, [editor, props.options?.fontSize, props.options?.lineHeight])
 
+    useEffect(() => {
+        editor?.setTextDirection(props.options?.textDirection)
+    }, [editor, props.options?.textDirection])
+
     useEffect(() => transport.addListener<{ slug: string }>('ScrollTo', ({ slug }) => {
         scrollToElement(`#${slug}`)
     }), [editor, scrollToElement]);
@@ -301,7 +305,8 @@ const MuyaEditor: React.FC<IMuyaEditor> = (props) => {
     return (
         <div style={{
             fontSize: props.options?.fontSize,
-            lineHeight: props.options?.lineHeight
+            lineHeight: props.options?.lineHeight,
+            fontFamily: props.options?.fontFamily ? `${props.options.fontFamily}, "Open Sans", "Segoe UI", sans-serif` : undefined
         }}>
             <div id="editor" />
         </div>

--- a/Dev/Typedown.Editor/src/components/Muya/lib/config/index.js
+++ b/Dev/Typedown.Editor/src/components/Muya/lib/config/index.js
@@ -250,6 +250,9 @@ export const EXPORT_DOMPURIFY_CONFIG = Object.freeze({
 export const MUYA_DEFAULT_OPTION = Object.freeze({
   fontSize: 16,
   lineHeight: 1.6,
+  fontFamily: '',
+  // 'auto' detects direction per block from its own text, 'ltr'/'rtl' force it.
+  textDirection: 'auto',
   focusMode: false,
   markdown: '',
   // Whether to trim the beginning and ending empty line in code block when open markdown.

--- a/Dev/Typedown.Editor/src/components/Muya/lib/index.js
+++ b/Dev/Typedown.Editor/src/components/Muya/lib/index.js
@@ -228,6 +228,11 @@ class Muya {
     this.contentState.render(false)
   }
 
+  setTextDirection(textDirection) {
+    this.options.textDirection = textDirection === 'ltr' || textDirection === 'rtl' ? textDirection : 'auto'
+    this.contentState.render(false)
+  }
+
   setTabSize(tabSize) {
     if (!tabSize || typeof tabSize !== 'number') {
       tabSize = 4

--- a/Dev/Typedown.Editor/src/components/Muya/lib/parser/render/renderBlock/renderContainerBlock.js
+++ b/Dev/Typedown.Editor/src/components/Muya/lib/parser/render/renderBlock/renderContainerBlock.js
@@ -6,6 +6,7 @@ import { renderEditIcon } from './renderContainerEditIcon'
 import renderCopyButton from './renderCopyButton'
 import { renderLeftBar, renderBottomBar } from './renderTableDargBar'
 import { h } from '../snabbdom'
+import { detectTextDirection, findBlockText } from '../../../utils/detectTextDirection'
 
 const PRE_BLOCK_HASH = {
   fencecode: `.${CLASS_OR_ID.AG_FENCE_CODE}`,
@@ -19,6 +20,11 @@ const PRE_BLOCK_HASH = {
   mermaid: `.${CLASS_OR_ID.AG_MERMAID}`,
   'vega-lite': `.${CLASS_OR_ID.AG_VEGA_LITE}`
 }
+
+// Block types that hold user-typed prose and should get a `dir` attribute so
+// Arabic/Hebrew paragraphs mixed with Latin ones each get correct direction
+// and alignment, instead of the whole document being forced to LTR.
+const TEXT_DIRECTION_TYPES = /^(?:p|h1|h2|h3|h4|h5|h6|li|blockquote|td|th)$/
 
 export default function renderContainerBlock (parent, block, activeBlocks, matches, useCache = false) {
   let selector = this.getSelector(block, activeBlocks)
@@ -47,6 +53,18 @@ export default function renderContainerBlock (parent, block, activeBlocks, match
   const data = {
     attrs: {},
     dataset: {}
+  }
+
+  if (TEXT_DIRECTION_TYPES.test(type)) {
+    const { textDirection } = this.muya.options
+    // Native `dir="auto"` isn't reliably re-evaluated by the browser as text
+    // is patched in by our virtual-dom renderer while typing, so detect the
+    // direction ourselves from the block's own text and emit a literal
+    // ltr/rtl value that snabbdom will keep in sync with the content.
+    const dir = textDirection === 'ltr' || textDirection === 'rtl'
+      ? textDirection
+      : detectTextDirection(findBlockText(block)) || 'ltr'
+    Object.assign(data.attrs, { dir })
   }
 
   if (editable === false) {

--- a/Dev/Typedown.Editor/src/components/Muya/lib/utils/detectTextDirection.js
+++ b/Dev/Typedown.Editor/src/components/Muya/lib/utils/detectTextDirection.js
@@ -1,0 +1,57 @@
+// First-strong-character direction detection (a practical subset of Unicode
+// UAX#9 rules P2/P3), used instead of the HTML `dir="auto"` attribute.
+// WebView2 does not reliably re-run `dir="auto"` detection as text is patched
+// in by our virtual-dom renderer while typing, so we compute the direction
+// ourselves on every render and emit a literal `ltr`/`rtl` value instead.
+//
+// Code point ranges (decimal), covering RTL scripts: Hebrew, Arabic, Syriac,
+// Arabic Supplement, Thaana, NKo (0x0591-0x07FF), Hebrew/Arabic presentation
+// forms A (0xFB1D-0xFDFF), Arabic presentation forms B (0xFE70-0xFEFF), plus
+// explicit RTL marks (RLM 0x200F, RLE 0x202B, RLO 0x202E).
+const RTL_RANGES = [
+  [0x0591, 0x07FF],
+  [0xFB1D, 0xFDFF],
+  [0xFE70, 0xFEFF]
+]
+const RTL_MARKS = new Set([0x200F, 0x202B, 0x202E])
+
+function isRtlCodePoint (codePoint) {
+  if (RTL_MARKS.has(codePoint)) {
+    return true
+  }
+  return RTL_RANGES.some(([start, end]) => codePoint >= start && codePoint <= end)
+}
+
+const LTR_LETTER_REG = /\p{L}/u
+
+export function detectTextDirection (text) {
+  if (!text) {
+    return null
+  }
+  for (const ch of text) {
+    const codePoint = ch.codePointAt(0)
+    if (isRtlCodePoint(codePoint)) {
+      return 'rtl'
+    }
+    if (LTR_LETTER_REG.test(ch)) {
+      return 'ltr'
+    }
+  }
+  return null
+}
+
+// Find the first non-empty `text` anywhere in a block's subtree.
+export function findBlockText (block) {
+  if (block.text) {
+    return block.text
+  }
+  if (Array.isArray(block.children)) {
+    for (const child of block.children) {
+      const text = findBlockText(child)
+      if (text) {
+        return text
+      }
+    }
+  }
+  return ''
+}

--- a/Dev/Typedown.Editor/src/components/Muya/themes/default.css
+++ b/Dev/Typedown.Editor/src/components/Muya/themes/default.css
@@ -343,7 +343,7 @@ kbd {
 
   ul,
   ol {
-    padding-left: 30px;
+    padding-inline-start: 30px;
   }
 
   ul:first-child,
@@ -368,13 +368,13 @@ kbd {
     height: 100%;
     width: 2px;
     position: absolute;
-    left: 15px;
+    inset-inline-start: 15px;
     top: 0;
     background: var(--themeColor);
   }
 
   blockquote blockquote {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
 
   table {
@@ -394,14 +394,14 @@ kbd {
 
   table tr th {
     font-weight: bold;
-    text-align: left;
+    text-align: start;
     margin: 0;
     padding: 6px 13px;
     position: relative;
   }
 
   table tr td {
-    text-align: left;
+    text-align: start;
     margin: 0;
     padding: 6px 13px;
     position: relative;


### PR DESCRIPTION
## Summary
- Paragraphs, headings, list items, blockquotes and table cells now get their text direction auto-detected per block from their own content (first-strong-character detection), instead of the editor being hardcoded LTR everywhere. This fixes rendering/alignment for Arabic, Hebrew, and other RTL content, including documents that mix RTL and LTR paragraphs.
- Added an explicit **Text direction** setting (Auto / LTR / RTL) under Settings → Editor for users who want to force a direction instead of relying on auto-detection.
- Added a **Font family** setting under Settings → Editor, backed by a live-filtered `AutoSuggestBox` listing every font actually installed on the user's system (via `System.Drawing.Text.InstalledFontCollection`), applied to both the WYSIWYG and source-code editors.
- Localized the new setting strings in English, Arabic, and Simplified Chinese (the project's default/neutral resource language).

## Why not rely on HTML `dir="auto"`?
The editor renders content through a virtual-DOM diffing pass (snabbdom) rather than relying on native contenteditable mutation, and the native `dir="auto"` attribute wasn't reliably re-evaluated by WebView2 as text got patched in while typing. Direction is now computed explicitly in JS from each block's own text on every render and emitted as a literal `ltr`/`rtl` value, using the same code path already proven to work for the manual override.

## Test plan
- [x] `tsc --noEmit` and `yarn build` pass cleanly for `Typedown.Editor`
- [x] Full solution build (`Typedown.Core` + `Typedown`) succeeds with 0 errors
- [x] Manually verified in the running app: typing Arabic text right-aligns automatically with Auto direction; explicit LTR/RTL override works; font family search filters to installed fonts as you type and applies to editor content